### PR TITLE
Change `checked_log` to `checked_ilog`

### DIFF
--- a/particle-builtins/src/math.rs
+++ b/particle-builtins/src/math.rs
@@ -51,7 +51,7 @@ pub fn pow(x: i64, y: u32) -> Result<i64, JError> {
 
 /// log_x(y) (logarithm of base x)
 pub fn log(x: i64, y: i64) -> Result<u32, JError> {
-    y.checked_log(x)
+    y.checked_ilog(x)
         .ok_or_else(|| JError::new("i64 log overflow"))
 }
 


### PR DESCRIPTION
[`checked_log`](https://doc.rust-lang.org/stable/std/primitive.i64.html#method.checked_log) method was renamed to `checked_ilog` in https://github.com/rust-lang/rust/pull/100332

`rust-ci` workflow uses nightly tool-chain so without this change tests would fail