### PR TITLE
ci: Run cargo build instead of nextest

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -80,17 +80,20 @@ jobs:
           package: air-interpreter-wasm
           version: ${{ inputs.air-interpreter-wasm-version }}
 
-      - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-nextest
-          version: "0.9"
+      # - name: Install cargo-nextest
+      #   uses: baptiste0928/cargo-install@v1
+      #   with:
+      #     crate: cargo-nextest
+      #     version: "0.9"
 
-      - name: Run cargo nextest
-        env:
-          NEXTEST_RETRIES: 2
-          NEXTEST_TEST_THREADS: 10
-        run: cargo nextest run --release --all-features --no-fail-fast
+      # - name: Run cargo nextest
+      #   env:
+      #     NEXTEST_RETRIES: 2
+      #     NEXTEST_TEST_THREADS: 10
+      #   run: cargo nextest run --release --all-features --no-fail-fast
+
+      - name: Run cargo build
+        run: cargo build --release -p particle-node
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Do not run cargo nextest when building snapshot.

TODO:
warn on test failure
run cargo next as a parallel job