### PR TITLE
ci: Set snapshot version in Cargo.toml

### DIFF
--- a/.github/snapshot/Dockerfile
+++ b/.github/snapshot/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:22.04
 COPY .github/snapshot/Config.toml .fluence/v1/Config.toml
-COPY target/release/particle-node /fluence
+COPY target/release/particle-node /usr/bin/fluence
 ENV RUST_LOG="info,aquamarine=warn,tokio_threadpool=info,tokio_reactor=info,mio=info,tokio_io=info,soketto=info,yamux=info,multistream_select=info,libp2p_secio=info,libp2p_websocket::framed=info,libp2p_ping=info,libp2p_core::upgrade::apply=info,libp2p_kad::kbucket=info,cranelift_codegen=info,wasmer_wasi=info,cranelift_codegen=info,wasmer_wasi=info"
 ENV RUST_BACKTRACE="1"
 ADD https://github.com/fluencelabs/trust-graph/releases/download/v3.0.4/trust-graph.tar.gz trust-graph.tar.gz
 RUN mkdir -p .fluence/v1/builtins && tar -C .fluence/v1/builtins -xf trust-graph.tar.gz && rm trust-graph.tar.gz
-ENTRYPOINT ["/fluence"]
+ENTRYPOINT ["/usr/bin/fluence"]
 CMD ["--local"]

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -112,7 +112,7 @@ jobs:
           SHA: ${{ steps.version.outputs.sha }}
           RUN: ${{ github.run_number }}
           ATTEMPT: ${{ github.run_attempt }}
-        working-directory: crates/particle-node
+        working-directory: particle-node
         run: |
           cargo set-version --bump alpha
           cargo set-version "$(cargo read-manifest | jq -r .version)-${{ env.BRANCH }}-${{ env.SHA }}-${{ env.RUN }}-${{ env.ATTEMPT }}"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -121,6 +121,12 @@ jobs:
       - name: Run cargo build
         run: cargo build --release -p particle-node
 
+      - name: Upload Cargo.lock
+        uses: actions/upload-artifact@v3
+        with:
+          name: rust-peer.Cargo.lock
+          path: Cargo.lock
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -156,22 +156,6 @@ jobs:
           RUST_PEER_IMAGE_NAME: ${{ inputs.image-name }}:${{ steps.version.outputs.branch }}
         run: |
           cat <<'SNAPSHOT' >> $GITHUB_STEP_SUMMARY
-          digest: `${{ env.RUST_PEER_IMAGE_SHA }}`
-          image: `${{ env.RUST_PEER_IMAGE_NAME }}`
-
-          To use it run:
-          ```shell
-          docker run --rm ${{ env.RUST_PEER_IMAGE_SHA }} --local
-          ```
-          SNAPSHOT
-
-      - name: Print results to check summary
-        if: always()
-        env:
-          RUST_PEER_IMAGE_SHA: ${{ inputs.image-name }}@${{ steps.docker.outputs.digest }}
-          RUST_PEER_IMAGE_NAME: ${{ inputs.image-name }}:${{ steps.version.outputs.branch }}
-        run: |
-          cat <<'SNAPSHOT' >> $GITHUB_STEP_SUMMARY
           ## rust-peer
           digest: `${{ env.RUST_PEER_IMAGE_SHA }}`
           image: `${{ env.RUST_PEER_IMAGE_NAME }}`

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -121,12 +121,6 @@ jobs:
       - name: Run cargo build
         run: cargo build --release -p particle-node
 
-      - name: Upload Cargo.lock
-        uses: actions/upload-artifact@v3
-        with:
-          name: rust-peer.Cargo.lock
-          path: Cargo.lock
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -151,7 +145,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Setup dasel
+        if: always()
+        uses: allejo/setup-dasel@v1
+
       - name: Print results to check summary
+        if: always()
         env:
           RUST_PEER_IMAGE_SHA: ${{ inputs.image-name }}@${{ steps.docker.outputs.digest }}
           RUST_PEER_IMAGE_NAME: ${{ inputs.image-name }}:${{ steps.version.outputs.branch }}
@@ -164,4 +163,26 @@ jobs:
           ```shell
           docker run --rm ${{ env.RUST_PEER_IMAGE_SHA }} --local
           ```
+          SNAPSHOT
+
+      - name: Print results to check summary
+        if: always()
+        env:
+          RUST_PEER_IMAGE_SHA: ${{ inputs.image-name }}@${{ steps.docker.outputs.digest }}
+          RUST_PEER_IMAGE_NAME: ${{ inputs.image-name }}:${{ steps.version.outputs.branch }}
+        run: |
+          cat <<'SNAPSHOT' >> $GITHUB_STEP_SUMMARY
+          ## rust-peer
+          digest: `${{ env.RUST_PEER_IMAGE_SHA }}`
+          image: `${{ env.RUST_PEER_IMAGE_NAME }}`
+
+          To use it run:
+          ```shell
+          docker run --rm ${{ env.RUST_PEER_IMAGE_SHA }} --local
+          ```
+          ## Used versions
+          | name   | version                                                                   |
+          | -------| ------------------------------------------------------------------------- |
+          | aquavm | $(dasel -f Cargo.lock -p toml 'package.(name=avm-server).version' -m)     |
+          | marine | $(dasel -f Cargo.lock -p toml 'package.(name=marine-runtime).version' -m) |
           SNAPSHOT

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -103,7 +103,6 @@ jobs:
           SHA=${{ github.event.pull_request.head.sha }}
           echo "sha=${SHA::7}" >> $GITHUB_OUTPUT
           echo "branch=${GITHUB_HEAD_REF//[^a-zA-Z0-9-]/-}" >> $GITHUB_OUTPUT
-          echo "name=${{ inputs.image-name }}:${branch}" >> $GITHUB_OUTPUT
 
       - name: Set package version
         id: build
@@ -140,7 +139,7 @@ jobs:
           push: true
           file: .github/snapshot/Dockerfile
           tags: |
-            ${{ steps.version.outputs.name }}
+            ${{ inputs.image-name }}:${{ steps.build.outputs.branch }}
           labels: |
             sha=${{ github.event.pull_request.head.sha }}
           cache-from: type=gha

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: builder
 
     outputs:
-      image: "${{ inputs.image-name }}@${{ steps.build.outputs.digest }}"
+      image: "${{ inputs.image-name }}@${{ steps.docker.outputs.digest }}"
 
     permissions:
       contents: read
@@ -133,7 +133,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Build and push snapshot
-        id: build
+        id: docker
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -157,7 +157,7 @@ jobs:
       - name: Update comment in PR
         uses: peter-evans/create-or-update-comment@v1
         env:
-          RUST_PEER_IMAGE_SHA: ${{ inputs.image-name }}@${{ steps.build.outputs.digest }}
+          RUST_PEER_IMAGE_SHA: ${{ inputs.image-name }}@${{ steps.docker.outputs.digest }}
         with:
           comment-id: "${{ steps.comment.outputs.comment-id }}"
           issue-number: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -92,6 +92,33 @@ jobs:
       #     NEXTEST_TEST_THREADS: 10
       #   run: cargo nextest run --release --all-features --no-fail-fast
 
+      - name: Install cargo-edit
+        uses: baptiste0928/cargo-install@v1.3.0
+        with:
+          crate: cargo-edit
+
+      - name: Generate package version
+        id: version
+        run: |
+          SHA=${{ github.event.pull_request.head.sha }}
+          echo "sha=${SHA::7}" >> $GITHUB_OUTPUT
+          echo "branch=${GITHUB_HEAD_REF//[^a-zA-Z0-9-]/-}" >> $GITHUB_OUTPUT
+          echo "name=${{ inputs.image-name }}:${branch}" >> $GITHUB_OUTPUT
+
+      - name: Set package version
+        id: build
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
+          SHA: ${{ steps.version.outputs.sha }}
+          RUN: ${{ github.run_number }}
+          ATTEMPT: ${{ github.run_attempt }}
+        working-directory: crates/particle-node
+        run: |
+          cargo set-version --bump alpha
+          cargo set-version "$(cargo read-manifest | jq -r .version)-${{ env.BRANCH }}-${{ env.SHA }}-${{ env.RUN }}-${{ env.ATTEMPT }}"
+
+          echo "version=$(cargo read-manifest | jq -r .version)" >> $GITHUB_OUTPUT
+
       - name: Run cargo build
         run: cargo build --release -p particle-node
 
@@ -105,12 +132,6 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
-      - name: Prepare image name
-        id: image
-        run: |
-          branch=${{ github.head_ref }}
-          echo "::set-output name=name::${{ inputs.image-name }}:${branch//[^a-zA-Z0-9-]/-}"
-
       - name: Build and push snapshot
         id: build
         uses: docker/build-push-action@v3
@@ -119,7 +140,7 @@ jobs:
           push: true
           file: .github/snapshot/Dockerfile
           tags: |
-            ${{ steps.image.outputs.name }}
+            ${{ steps.version.outputs.name }}
           labels: |
             sha=${{ github.event.pull_request.head.sha }}
           cache-from: type=gha

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Print results to check summary
         env:
           RUST_PEER_IMAGE_SHA: ${{ inputs.image-name }}@${{ steps.docker.outputs.digest }}
-          RUST_PEER_IMAGE_NAME: ${{ inputs.image-name }}@${{ steps.version.outputs.name }}
+          RUST_PEER_IMAGE_NAME: ${{ inputs.image-name }}:${{ steps.version.outputs.branch }}
         run: |
           cat <<'SNAPSHOT' >> $GITHUB_STEP_SUMMARY
           digest: `${{ env.RUST_PEER_IMAGE_SHA }}`

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -180,9 +180,11 @@ jobs:
           ```shell
           docker run --rm ${{ env.RUST_PEER_IMAGE_SHA }} --local
           ```
+          SNAPSHOT
+          cat <<VERSIONS >> $GITHUB_STEP_SUMMARY
           ## Used versions
           | name   | version                                                                   |
           | -------| ------------------------------------------------------------------------- |
           | aquavm | $(dasel -f Cargo.lock -p toml 'package.(name=avm-server).version' -m)     |
           | marine | $(dasel -f Cargo.lock -p toml 'package.(name=marine-runtime).version' -m) |
-          SNAPSHOT
+          VERSIONS

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -139,7 +139,7 @@ jobs:
           push: true
           file: .github/snapshot/Dockerfile
           tags: |
-            ${{ inputs.image-name }}:${{ steps.build.outputs.branch }}
+            ${{ inputs.image-name }}:${{ steps.version.outputs.branch }}
           labels: |
             sha=${{ github.event.pull_request.head.sha }}
           cache-from: type=gha

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -145,27 +145,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Find comment in PR
-        uses: peter-evans/find-comment@v1
-        id: comment
-        with:
-          issue-number: "${{ github.event.pull_request.number }}"
-          comment-author: github-actions[bot]
-          body-includes: "## rust-peer"
-
-      - name: Update comment in PR
-        uses: peter-evans/create-or-update-comment@v1
+      - name: Print results to check summary
         env:
           RUST_PEER_IMAGE_SHA: ${{ inputs.image-name }}@${{ steps.docker.outputs.digest }}
-        with:
-          comment-id: "${{ steps.comment.outputs.comment-id }}"
-          issue-number: "${{ github.event.pull_request.number }}"
-          edit-mode: replace
-          body: |
-            ## rust-peer
-            Docker snapshot digest is `${{ env.RUST_PEER_IMAGE_SHA }}`
-            To use it run:
-            ```shell
-            docker login docker.fluence.dev
-            docker run --rm ${{ env.RUST_PEER_IMAGE_SHA }} --local
-            ```
+          RUST_PEER_IMAGE_NAME: ${{ inputs.image-name }}@${{ steps.version.outputs.name }}
+        run: |
+          cat <<'SNAPSHOT' >> $GITHUB_STEP_SUMMARY
+          digest: `${{ env.RUST_PEER_IMAGE_SHA }}`
+          image: `${{ env.RUST_PEER_IMAGE_NAME }}`
+
+          To use it run:
+          ```shell
+          docker run --rm ${{ env.RUST_PEER_IMAGE_SHA }} --local
+          ```
+          SNAPSHOT


### PR DESCRIPTION
- set version in `Cargo.toml` so `fluence --version` displays something like `Fluence node 0.7.2-alpha.1-set-version-snapshot-463ee7f-138-1; AIR version 0.31.4`
- migrate `set-output` to new format to get read of warnings
- print instructions on how to run rust-peer snapshot to checks summary instead of comment