### PR TITLE
Draft: basic spells instalation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,6 +3958,7 @@ dependencies = [
  "connection-pool",
  "derivative",
  "eyre",
+ "fluence-app-service",
  "fluence-keypair",
  "futures",
  "humantime-serde",
@@ -3984,6 +3985,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml-utils",
+ "uuid-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3982,6 +3982,7 @@ dependencies = [
  "serde",
  "serde_json",
  "server-config",
+ "spell-storage",
  "tempfile",
  "thiserror",
  "toml-utils",
@@ -5306,6 +5307,14 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha-1",
+]
+
+[[package]]
+name = "spell-storage"
+version = "0.1.0"
+dependencies = [
+ "derivative",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "particle-modules",
     "connection-pool",
     "script-storage",
+    "spell-storage",
     "particle-execution",
 ]
 exclude = [
@@ -60,3 +61,4 @@ fluence-keypair = "0.8.1"
 parking_lot = "0.12.1"
 async-std = { version = "1.12.0", features = ["unstable"] }
 uuid = { version = "1.2.1", features = ["v4"] }
+derivative = "2.2.0"

--- a/crates/server-config/src/dir_config.rs
+++ b/crates/server-config/src/dir_config.rs
@@ -49,6 +49,10 @@ pub struct UnresolvedDirConfig {
     /// Path to AIR interpreter .wasm file (aquamarine.wasm)
     #[serde(default)]
     pub air_interpreter_path: Option<PathBuf>,
+
+    /// Path to spells service bundle
+    #[serde(default)]
+    pub spell_base_dir: Option<PathBuf>,
 }
 
 impl UnresolvedDirConfig {
@@ -61,6 +65,7 @@ impl UnresolvedDirConfig {
         let air_interpreter_path = self
             .air_interpreter_path
             .unwrap_or(air_interpreter_path(&base));
+        let spell_base_dir = self.spell_base_dir.unwrap_or(base.join("spell_bundle"));
 
         ResolvedDirConfig {
             base_dir: base,
@@ -69,6 +74,7 @@ impl UnresolvedDirConfig {
             builtins_base_dir,
             avm_base_dir,
             air_interpreter_path,
+            spell_base_dir,
         }
     }
 }
@@ -84,6 +90,7 @@ pub struct ResolvedDirConfig {
     pub avm_base_dir: PathBuf,
     /// Directory where interpreter's WASM module is stored
     pub air_interpreter_path: PathBuf,
+    pub spell_base_dir: PathBuf,
 }
 
 impl ResolvedDirConfig {

--- a/crates/server-config/src/services_config.rs
+++ b/crates/server-config/src/services_config.rs
@@ -47,6 +47,8 @@ pub struct ServicesConfig {
     pub max_heap_size: ByteSize,
     /// Default heap size in bytes available for the module unless otherwise specified.
     pub default_heap_size: Option<ByteSize>,
+    /// Path to the spells service bundle
+    pub spells_base_dir: PathBuf,
 }
 
 impl ServicesConfig {
@@ -59,6 +61,7 @@ impl ServicesConfig {
         builtins_management_peer_id: PeerId,
         max_heap_size: ByteSize,
         default_heap_size: Option<ByteSize>,
+        spells_base_dir: PathBuf,
     ) -> Result<Self, std::io::Error> {
         let base_dir = to_abs_path(base_dir);
 
@@ -74,6 +77,7 @@ impl ServicesConfig {
             builtins_management_peer_id,
             max_heap_size,
             default_heap_size,
+            spells_base_dir,
         };
 
         create_dirs(&[

--- a/particle-builtins/Cargo.toml
+++ b/particle-builtins/Cargo.toml
@@ -19,6 +19,7 @@ ivalue-utils = { path = "../crates/ivalue-utils" }
 now-millis = { path = "../crates/now-millis" }
 toml-utils = { path = "../crates/toml-utils" }
 peer-metrics = { path = "../crates/peer-metrics" }
+uuid-utils = { path = "../crates/uuid-utils/" }
 
 libp2p = { workspace = true }
 avm-server = { workspace = true }
@@ -38,6 +39,7 @@ futures = "0.3.24"
 itertools = "0.10.5"
 bytesize = "1.1.0"
 derivative = "2.2.0"
+fluence-app-service = { workspace = true }
 
 eyre = { workspace = true }
 

--- a/particle-builtins/Cargo.toml
+++ b/particle-builtins/Cargo.toml
@@ -11,6 +11,7 @@ particle-services = { path = "../particle-services"}
 particle-modules = { path = "../particle-modules"}
 connection-pool = { path = "../connection-pool"}
 script-storage = { path = "../script-storage"}
+spell-storage = { path = "../spell-storage"}
 
 server-config = { path = "../crates/server-config"}
 kademlia = { path = "../crates/kademlia"}
@@ -38,7 +39,7 @@ rand = "0.8.5"
 futures = "0.3.24"
 itertools = "0.10.5"
 bytesize = "1.1.0"
-derivative = "2.2.0"
+derivative = { workspace = true }
 fluence-app-service = { workspace = true }
 
 eyre = { workspace = true }

--- a/particle-modules/src/lib.rs
+++ b/particle-modules/src/lib.rs
@@ -34,7 +34,7 @@ mod files;
 mod modules;
 
 pub use error::ModuleError;
-pub use files::{list_files, load_blueprint, load_module_descriptor};
+pub use files::{list_files, load_blueprint, load_module_by_path, load_module_descriptor};
 pub use modules::{AddBlueprint, ModuleRepository};
 
 // reexport

--- a/particle-modules/src/modules.rs
+++ b/particle-modules/src/modules.rs
@@ -165,7 +165,11 @@ impl ModuleRepository {
 
         Ok(())
     }
-    fn add_module(&self, module: Vec<u8>, config: TomlMarineNamedModuleConfig) -> Result<String> {
+    pub fn add_module(
+        &self,
+        module: Vec<u8>,
+        config: TomlMarineNamedModuleConfig,
+    ) -> Result<String> {
         let hash = Hash::hash(&module);
 
         let mut config = files::add_module(&self.modules_dir, &hash, &module, config)?;

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -112,6 +112,7 @@ impl<RT: AquaRuntime> Node<RT> {
             builtins_peer_id,
             config.node_config.module_max_heap_size,
             config.node_config.module_default_heap_size,
+            config.dir_config.spell_base_dir.clone(),
         )
         .expect("create services config");
 

--- a/spell-storage/Cargo.toml
+++ b/spell-storage/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "spell-storage"
+version = "0.1.0"
+authors = ["Fluence Labs"]
+edition = "2018"
+
+[dependencies]
+parking_lot = { workspace = true }
+derivative = { workspace = true }

--- a/spell-storage/src/lib.rs
+++ b/spell-storage/src/lib.rs
@@ -1,0 +1,3 @@
+mod storage;
+
+pub use crate::storage::SpellStorage;

--- a/spell-storage/src/storage.rs
+++ b/spell-storage/src/storage.rs
@@ -32,7 +32,7 @@ impl SpellStorage {
     }
 
     pub fn unregister_spell(&self, spell_id: &str) {
-        self.registered_spells.write().retain(|id| id != &spell_id);
+        self.registered_spells.write().retain(|id| id != spell_id);
     }
 
     pub fn has_spell(&self, spell_id: &str) -> bool {

--- a/spell-storage/src/storage.rs
+++ b/spell-storage/src/storage.rs
@@ -1,0 +1,49 @@
+use derivative::Derivative;
+use parking_lot::RwLock;
+use std::collections::HashSet;
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct SpellStorage {
+    // The blueprint for the latest spell service.
+    spell_blueprint_id: String,
+    // All blueprints that are used for spells
+    all_spell_blueprint_ids: HashSet<String>,
+    // All currently existing spells
+    registered_spells: RwLock<HashSet<String>>,
+}
+
+impl SpellStorage {
+    pub fn new(
+        spell_blueprint_id: String,
+        all_spell_blueprint_ids: HashSet<String>,
+        registered_spells: HashSet<String>,
+    ) -> Self {
+        Self {
+            spell_blueprint_id,
+            all_spell_blueprint_ids,
+            registered_spells: RwLock::new(registered_spells),
+        }
+    }
+
+    pub fn register_spell(&self, spell_id: String) {
+        let mut spells = self.registered_spells.write();
+        spells.insert(spell_id);
+    }
+
+    pub fn unregister_spell(&self, spell_id: &str) {
+        self.registered_spells.write().retain(|id| id != &spell_id);
+    }
+
+    pub fn has_spell(&self, spell_id: &str) -> bool {
+        self.registered_spells.read().contains(spell_id)
+    }
+
+    pub fn get_registered_spells(&self) -> HashSet<String> {
+        self.registered_spells.read().clone()
+    }
+
+    pub fn get_blueprint(&self) -> String {
+        self.spell_blueprint_id.clone()
+    }
+}


### PR DESCRIPTION
Need to manually place the spell service to `.fluence/v1/spell_bundle` or any path configured with `spell_base_dir` option.

```aqua
service Spell("spell"):
  list() -> []string
  install(script: string) -> string
  remove(script: string)
```