### PR TITLE
Draft: add spell scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,22 +1716,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-dispatcher"
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "events-dispatcher"
 version = "0.1.0"
 dependencies = [
  "async-std",
  "derivative",
  "fluence-libp2p",
  "futures",
+ "log",
  "parking_lot 0.12.1",
  "thiserror",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eyre"
@@ -3969,6 +3970,7 @@ dependencies = [
  "bytesize",
  "connection-pool",
  "derivative",
+ "events-dispatcher",
  "eyre",
  "fluence-app-service",
  "fluence-keypair",
@@ -4065,6 +4067,7 @@ dependencies = [
  "criterion",
  "ctrlc-adapter",
  "env_logger 0.9.1",
+ "events-dispatcher",
  "eyre",
  "fluence-app-service",
  "fluence-keypair",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,6 +1716,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-dispatcher"
+version = "0.1.0"
+dependencies = [
+ "async-std",
+ "derivative",
+ "fluence-libp2p",
+ "futures",
+ "parking_lot 0.12.1",
+ "thiserror",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/connected-client",
     "crates/test-constants",
     "crates/peer-metrics",
+    "crates/events-dispatcher",
     "particle-node/tests/builtins",
     "particle-node",
     "aquamarine",

--- a/crates/events-dispatcher/Cargo.toml
+++ b/crates/events-dispatcher/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "event-dispatcher"
+version = "0.1.0"
+authors = ["Fluence Labs"]
+edition = "2018"
+
+[dependencies]
+parking_lot = { workspace = true }
+async-std = { workspace = true }
+derivative = { workspace = true }
+futures = "0.3.24"
+fluence-libp2p = { path = "../libp2p" }
+thiserror = "1.0.37"

--- a/crates/events-dispatcher/Cargo.toml
+++ b/crates/events-dispatcher/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "event-dispatcher"
+name = "events-dispatcher"
 version = "0.1.0"
 authors = ["Fluence Labs"]
 edition = "2018"
@@ -11,3 +11,4 @@ derivative = { workspace = true }
 futures = "0.3.24"
 fluence-libp2p = { path = "../libp2p" }
 thiserror = "1.0.37"
+log = "0.4.17"

--- a/crates/events-dispatcher/src/lib.rs
+++ b/crates/events-dispatcher/src/lib.rs
@@ -1,0 +1,2 @@
+#![feature(binary_heap_retain)]
+pub mod scheduler;

--- a/crates/events-dispatcher/src/scheduler/api.rs
+++ b/crates/events-dispatcher/src/scheduler/api.rs
@@ -1,0 +1,42 @@
+use fluence_libp2p::types::Outlet;
+use std::time::Duration;
+use thiserror::Error;
+
+pub struct TimerConfig {
+    pub period: Duration,
+}
+
+pub enum Command {
+    Add { id: String, config: TimerConfig },
+    Remove { id: String },
+}
+
+#[derive(Error, Debug)]
+pub enum SchedulerError {
+    #[error("can't send a message to the scheduler")]
+    CommandSendError,
+}
+
+pub struct SchedulerApi {
+    send_command: Outlet<Command>,
+}
+
+impl SchedulerApi {
+    pub fn new(send_command: Outlet<Command>) -> Self {
+        Self { send_command }
+    }
+
+    fn send(&self, command: Command) -> Result<(), SchedulerError> {
+        self.send_command
+            .unbounded_send(command)
+            .map_err(|_| SchedulerError::CommandSendError)
+    }
+
+    pub fn add(&self, id: String, config: TimerConfig) -> Result<(), SchedulerError> {
+        self.send(Command::Add { id, config })
+    }
+
+    pub fn remove(&self, id: String) -> Result<(), SchedulerError> {
+        self.send(Command::Remove { id })
+    }
+}

--- a/crates/events-dispatcher/src/scheduler/api.rs
+++ b/crates/events-dispatcher/src/scheduler/api.rs
@@ -1,11 +1,14 @@
 use fluence_libp2p::types::Outlet;
+use std::fmt;
 use std::time::Duration;
 use thiserror::Error;
 
+#[derive(Debug)]
 pub struct TimerConfig {
     pub period: Duration,
 }
 
+#[derive(Debug)]
 pub enum Command {
     Add { id: String, config: TimerConfig },
     Remove { id: String },
@@ -19,6 +22,12 @@ pub enum SchedulerError {
 
 pub struct SchedulerApi {
     send_command: Outlet<Command>,
+}
+
+impl fmt::Debug for SchedulerApi {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SchedulerApi").finish()
+    }
 }
 
 impl SchedulerApi {

--- a/crates/events-dispatcher/src/scheduler/mod.rs
+++ b/crates/events-dispatcher/src/scheduler/mod.rs
@@ -17,6 +17,7 @@ struct Periodic<T> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct Scheduled<T> {
     data: Periodic<T>,
+    // the time after we need to run the task
     run_at: Instant,
 }
 
@@ -32,6 +33,7 @@ impl<T: Eq> Scheduled<T> {
     }
 }
 
+// Implement it this way for min heap
 impl<T: PartialEq + Eq> Ord for Scheduled<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         other.run_at.cmp(&self.run_at)
@@ -51,6 +53,7 @@ pub struct SchedulerConfig {
 pub struct Scheduler {
     timer_resolution: Duration,
     recv_command: Inlet<Command>,
+    // what to run when its time to execute the task
     callback: Box<dyn Fn(&str) + Send>,
 }
 

--- a/crates/events-dispatcher/src/scheduler/mod.rs
+++ b/crates/events-dispatcher/src/scheduler/mod.rs
@@ -1,0 +1,151 @@
+pub mod api;
+
+use crate::scheduler::api::*;
+use async_std::task::JoinHandle;
+use fluence_libp2p::types::Inlet;
+use futures::{channel::mpsc::unbounded, select, StreamExt};
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Periodic<T> {
+    pub id: T,
+    pub period: Duration,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Scheduled<T> {
+    data: Periodic<T>,
+    run_at: Instant,
+}
+
+impl<T: Eq> Scheduled<T> {
+    fn new(data: Periodic<T>, now: Instant) -> Scheduled<T> {
+        let run_at = now.checked_add(data.period).expect("time overflow?");
+        Scheduled { data, run_at }
+    }
+
+    fn reschedule(mut self, now: Instant) -> Scheduled<T> {
+        self.run_at = now.checked_add(self.data.period).expect("time overflow?");
+        self
+    }
+}
+
+impl<T: PartialEq + Eq> Ord for Scheduled<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.run_at.cmp(&self.run_at)
+    }
+}
+
+impl<T: Eq> PartialOrd for Scheduled<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub struct SchedulerConfig {
+    timer_resolution: Duration,
+}
+
+pub struct Scheduler<F>
+where
+    F: Fn(&str) + Send + 'static,
+{
+    timer_resolution: Duration,
+    recv_command: Inlet<Command>,
+    callback: F,
+}
+
+impl<F> Scheduler<F>
+where
+    F: Fn(&str) + Send + 'static,
+{
+    pub fn new(config: SchedulerConfig, callback: F) -> (Self, SchedulerApi) {
+        let (send, recv) = unbounded();
+        let api = SchedulerApi::new(send);
+        let this = Self {
+            timer_resolution: config.timer_resolution,
+            recv_command: recv,
+            callback,
+        };
+        (this, api)
+    }
+
+    pub fn start(self) -> JoinHandle<()> {
+        async_std::task::spawn(async move {
+            let timer_resolution = self.timer_resolution;
+            let mut command_channel = self.recv_command.fuse();
+            let mut timer = async_std::stream::interval(timer_resolution).fuse();
+            let mut heap: BinaryHeap<Scheduled<String>> = BinaryHeap::new();
+            let callback = self.callback;
+            loop {
+                select!(
+                    _ = timer.select_next_some() => {
+                        let now = Instant::now();
+                        while let Some(task) = heap.peek() {
+                            if task.run_at > now {
+                                break;
+                            }
+                            let task = heap.pop().unwrap();
+                            callback(&task.data.id);
+                            heap.push(task.reschedule(now));
+                        }
+                    },
+                    command = command_channel.select_next_some() => {
+                        match command {
+                            Command::Add { id , config } => {
+                                let periodic = Periodic { id, period: config.period };
+                                heap.push(Scheduled::new(periodic, Instant::now()))
+                            },
+                            Command::Remove { id } => {
+                                heap.retain(|scheduled| scheduled.data.id != id);
+                            },
+                        }
+                    }
+                );
+            }
+        })
+    }
+}
+
+#[test]
+fn test1() {
+    let (scheduler, api) = Scheduler::new(
+        SchedulerConfig {
+            timer_resolution: Duration::from_secs(1),
+        },
+        |id| println!("{:?}", id),
+    );
+    let _ = scheduler.start();
+
+    api.add(
+        "spell1".to_string(),
+        TimerConfig {
+            period: Duration::from_secs(1),
+        },
+    )
+    .unwrap();
+    api.add(
+        "spell2".to_string(),
+        TimerConfig {
+            period: Duration::from_secs(3),
+        },
+    )
+    .unwrap();
+    task::block_on(async { task::sleep(Duration::from_secs(10)).await });
+
+    println!("remove spell2");
+    api.remove("spell2".to_string()).unwrap();
+    task::block_on(async { task::sleep(Duration::from_secs(10)).await });
+
+    println!("add spell3");
+    api.add(
+        "spell3".to_string(),
+        TimerConfig {
+            period: Duration::from_secs(4),
+        },
+    )
+    .unwrap();
+    task::block_on(async { task::sleep(Duration::from_secs(10)).await });
+}

--- a/particle-builtins/Cargo.toml
+++ b/particle-builtins/Cargo.toml
@@ -21,6 +21,7 @@ now-millis = { path = "../crates/now-millis" }
 toml-utils = { path = "../crates/toml-utils" }
 peer-metrics = { path = "../crates/peer-metrics" }
 uuid-utils = { path = "../crates/uuid-utils/" }
+events-dispatcher = { path = "../crates/events-dispatcher"}
 
 libp2p = { workspace = true }
 avm-server = { workspace = true }

--- a/particle-node/Cargo.toml
+++ b/particle-node/Cargo.toml
@@ -21,6 +21,7 @@ air-interpreter-fs = { path = "../crates/air-interpreter-fs" }
 builtins-deployer = { path = "../crates/builtins-deployer" }
 fs-utils = { path = "../crates/fs-utils" }
 peer-metrics = { path = "../crates/peer-metrics" }
+events-dispatcher = { path = "../crates/events-dispatcher/" }
 
 fluence-keypair = { workspace = true }
 

--- a/spell-storage/src/storage.rs
+++ b/spell-storage/src/storage.rs
@@ -26,24 +26,24 @@ impl SpellStorage {
         }
     }
 
-    pub fn register_spell(&self, spell_id: String) {
-        let mut spells = self.registered_spells.write();
-        spells.insert(spell_id);
-    }
-
-    pub fn unregister_spell(&self, spell_id: &str) {
-        self.registered_spells.write().retain(|id| id != spell_id);
-    }
-
-    pub fn has_spell(&self, spell_id: &str) -> bool {
-        self.registered_spells.read().contains(spell_id)
-    }
-
     pub fn get_registered_spells(&self) -> HashSet<String> {
         self.registered_spells.read().clone()
     }
 
     pub fn get_blueprint(&self) -> String {
         self.spell_blueprint_id.clone()
+    }
+
+    pub fn register_spell(&self, spell_id: String) {
+        let mut spells = self.registered_spells.write();
+        spells.insert(spell_id);
+    }
+
+    pub fn unregister_spell(&self, spell_id: &String) {
+        self.registered_spells.write().retain(|id| id != spell_id);
+    }
+
+    pub fn has_spell(&self, spell_id: &String) -> bool {
+        self.registered_spells.read().contains(spell_id)
     }
 }


### PR DESCRIPTION
Not yet a generic event dispatcher though. Also doesn't really send anything anywhere. 

Extend spell interface to
```aqua
service Spell("spell"):
  list() -> []string
  install(script: string, period: u32) -> string
  remove(script: string)

func install() -> string:
   on HOST_PEER_ID:
     sid <- Spell.install("(noop)", 5)
   <- sid
```