### PR TITLE
Add spell rescheduling after restart

### DIFF
--- a/crates/spell-event-bus/src/bus.rs
+++ b/crates/spell-event-bus/src/bus.rs
@@ -284,7 +284,7 @@ mod tests {
             spell1_id.clone(),
             SpellTriggerConfigs {
                 triggers: vec![TriggerConfig::Timer(TimerConfig {
-                    period: spell1_period,
+                    period: spell1_period.clone(),
                     start_at: Instant::now(),
                     end_at: None,
                 })],
@@ -296,7 +296,7 @@ mod tests {
             SpellTriggerConfigs {
                 triggers: vec![TriggerConfig::Timer(TimerConfig {
                     period: spell2_period,
-                    start_at: Instant::now(),
+                    start_at: Instant::now() + spell2_period,
                     end_at: None,
                 })],
             },

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -227,8 +227,6 @@ impl<RT: AquaRuntime> Node<RT> {
             .map(|x| PeerEvent::ConnectionPool(x))
             .boxed()];
 
-        // Unfortunately, API is available before the bus is running. It's used for creating spell builtins.
-        // That means that calling api before the bus is running will block execution.
         let (spell_event_bus, spell_event_bus_api, spell_events_stream) =
             SpellEventBus::new(sources);
 
@@ -394,7 +392,6 @@ impl<RT: AquaRuntime> Node<RT> {
 
             let services_metrics_backend = services_metrics_backend.start();
             let script_storage = script_storage.start();
-            // Spell bus must be run before sorcerer, because sorcerer may send events to the bus
             let spell_event_bus = spell_event_bus.start();
             let sorcerer = sorcerer.start(spell_events_stream);
             let pool = aquavm_pool.start();

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -226,6 +226,9 @@ impl<RT: AquaRuntime> Node<RT> {
         let sources = vec![recv_connection_pool_events
             .map(|x| PeerEvent::ConnectionPool(x))
             .boxed()];
+
+        // Unfortunately, API is available before the bus is running. It's used for creating spell builtins.
+        // That means that calling api before the bus is running will block execution.
         let (spell_event_bus, spell_event_bus_api, spell_events_stream) =
             SpellEventBus::new(sources);
 
@@ -391,6 +394,7 @@ impl<RT: AquaRuntime> Node<RT> {
 
             let services_metrics_backend = services_metrics_backend.start();
             let script_storage = script_storage.start();
+            // Spell bus must be run before sorcerer, because sorcerer may send events to the bus
             let spell_event_bus = spell_event_bus.start();
             let sorcerer = sorcerer.start(spell_events_stream);
             let pool = aquavm_pool.start();

--- a/sorcerer/src/lib.rs
+++ b/sorcerer/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(try_blocks)]
 pub use sorcerer::Sorcerer;
 
 #[macro_use]

--- a/sorcerer/src/sorcerer.rs
+++ b/sorcerer/src/sorcerer.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use async_std::task;
 use std::collections::HashMap;
 use std::time::Duration;
 

--- a/sorcerer/src/sorcerer.rs
+++ b/sorcerer/src/sorcerer.rs
@@ -90,9 +90,8 @@ impl Sorcerer {
 
     async fn reschedule_spells(&self) {
         for spell_id in self.spell_storage.get_registered_spells() {
-            log::warn!("Rescheduling spell {}", spell_id);
+            log::info!("Rescheduling spell {}", spell_id);
             let result: Result<(), JError> = try {
-                log::warn!("getting trigger config");
                 let result = process_func_outcome::<TriggerConfigValue>(
                     self.services.call_function(
                         &spell_id,
@@ -105,9 +104,7 @@ impl Sorcerer {
                     &spell_id,
                     "get_trigger_config",
                 )?;
-                log::warn!("parsing trigger config");
                 let config = from_user_config(result.config)?;
-                log::warn!("subscribing to event bus");
                 self.spell_event_bus_api
                     .subscribe(spell_id.clone(), config.clone())
                     .await?;

--- a/sorcerer/src/sorcerer.rs
+++ b/sorcerer/src/sorcerer.rs
@@ -105,12 +105,6 @@ impl Sorcerer {
                     &spell_id,
                     "get_trigger_config",
                 )?;
-                if !result.success {
-                    Err(JError::new(format!(
-                        "Failed to get trigger config for spell {}: {}",
-                        spell_id, result.error
-                    )))?;
-                }
                 log::warn!("parsing trigger config");
                 let config = from_user_config(result.config)?;
                 log::warn!("subscribing to event bus");

--- a/sorcerer/src/utils.rs
+++ b/sorcerer/src/utils.rs
@@ -40,15 +40,20 @@ where
         ))),
         FunctionOutcome::Err(err) => Err(JError::new(err.to_string())),
         FunctionOutcome::Ok(v) => {
-            let result = serde_json::from_value::<T>(v)?;
-            if result.is_success() {
-                Ok(result)
-            } else {
-                Err(JError::new(format!(
+            let result = serde_json::from_value::<T>(v).map_err(|e| {
+                JError::new(format!(
                     "Result of a function {}.{} cannot be parsed to {}: {}",
                     spell_id,
                     function_name,
                     std::any::type_name::<T>(),
+                    e
+                ))
+            })?;
+            if result.is_success() {
+                Ok(result)
+            } else {
+                Err(JError::new(format!(
+                    "Function {spell_id}.{function_name} executed with error: {}",
                     result.get_error()
                 )))
             }


### PR DESCRIPTION
This can be considered a fast implementation because there are some parts I don't like:
1. Event bus API is available before it can be used because of all API methods, despite being async, wait for the result from the event bus. The result is just a unit that states that the command was processed.
2. Rescheduling spell happens in the `start` methods, merely before the sorcerer starts. Doesn't look good. 

Event bus API is used in sorcerer, so we can't just create it on event-bus start and then pass it to `sorcerer.start(api)`.

So solutions I see are:
1. Start event bus before sorcerer creation in `Node::new`. Doesn't look like a good place for spawning processes, though. 
2. Make rescheduling spells an explicit separate step and call it after the event bus and sorcerer start (somehow preserving all necessary fields of the latter). 
3. Do something else? Maybe we don't want to execute particles before the node is fully initialized for reasons I'm not yet aware of and pursue another approach. 
