### PR TITLE
Enable spell removal api

### DIFF
--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -796,9 +796,8 @@ where
     fn remove_service(&self, args: Args, params: ParticleParams) -> Result<(), JError> {
         let mut args = args.function_args.into_iter();
         let service_id_or_alias: String = Args::next("service_id_or_alias", &mut args)?;
-
         self.services
-            .remove_service(service_id_or_alias, params.init_peer_id)?;
+            .remove_service(service_id_or_alias, params.init_peer_id, false)?;
         Ok(())
     }
 

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -162,6 +162,7 @@ impl ParticleAppServices {
         &self,
         service_id_or_alias: String,
         init_peer_id: PeerId,
+        allow_remove_spell: bool,
     ) -> Result<(), ServiceError> {
         let removal_start_time = Instant::now();
         let service_id = {
@@ -175,11 +176,18 @@ impl ParticleAppServices {
                 .modules
                 .get_blueprint_from_cache(&service.blueprint_id)?
                 .name;
-            if blueprint_name == "spell" {
+            if blueprint_name == "spell" && !allow_remove_spell {
                 return Err(Forbidden {
                     user: init_peer_id,
                     function: "remove_service",
                     reason: "cannot remove a spell",
+                }
+                .into());
+            } else if blueprint_name != "spell" && allow_remove_spell {
+                return Err(Forbidden {
+                    user: init_peer_id,
+                    function: "remove_spell",
+                    reason: "the service isn't a spell",
                 }
                 .into());
             }

--- a/sorcerer/src/spells.rs
+++ b/sorcerer/src/spells.rs
@@ -94,7 +94,7 @@ pub(crate) async fn spell_install(
         log::warn!("can't subscribe a spell {} to triggers {:?} via spell-event-bus-api: {}. Removing created spell service...", spell_id, config, err);
 
         spell_storage.unregister_spell(&spell_id);
-        services.remove_service(spell_id, params.init_peer_id)?;
+        services.remove_service(spell_id, params.init_peer_id, true)?;
 
         return Err(JError::new(format!(
             "can't install a spell due to an internal error while subscribing to the triggers: {}",
@@ -139,7 +139,7 @@ pub(crate) async fn spell_remove(
 
     // TODO: remove spells by aliases too
     spell_storage.unregister_spell(&spell_id);
-    services.remove_service(spell_id, params.init_peer_id)?;
+    services.remove_service(spell_id, params.init_peer_id, true)?;
     Ok(())
 }
 


### PR DESCRIPTION
Now I see only a hack way to implement spells removal. And I think we need to enable it.

We need to somehow detect whether the given id is a spell, but now I don't see how we can share `spell_storage` info with `builtins` to do it the right way. 