### PR TITLE
feat(spells): store trigger info in spell mailbox [NET-225]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5495,6 +5495,7 @@ dependencies = [
  "particle-execution",
  "particle-protocol",
  "particle-services",
+ "serde",
  "serde_json",
  "thiserror",
  "uuid-utils",

--- a/crates/spell-event-bus/Cargo.toml
+++ b/crates/spell-event-bus/Cargo.toml
@@ -15,6 +15,7 @@ fluence-libp2p = { path = "../libp2p" }
 
 parking_lot = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
 async-std = { workspace = true }
 derivative = { workspace = true }
 eyre = { workspace = true }

--- a/crates/spell-event-bus/src/api.rs
+++ b/crates/spell-event-bus/src/api.rs
@@ -90,6 +90,7 @@ impl From<TriggerInfo> for TriggerInfoAqua {
         }
     }
 }
+
 #[derive(Debug)]
 pub(crate) struct Command {
     pub(crate) spell_id: SpellId,

--- a/crates/spell-event-bus/src/api.rs
+++ b/crates/spell-event-bus/src/api.rs
@@ -81,7 +81,7 @@ impl From<TriggerInfo> for TriggerInfoAqua {
         match i {
             TriggerInfo::Timer(t) => Self {
                 timer: vec![t],
-                peer: vec![],
+                peer: vec![], // Empty Vec corresponds to Aqua nil
             },
             TriggerInfo::Peer(p) => Self {
                 timer: vec![],

--- a/crates/spell-event-bus/src/api.rs
+++ b/crates/spell-event-bus/src/api.rs
@@ -72,7 +72,9 @@ pub enum PeerEventType {
 
 #[derive(Serialize)]
 pub struct TriggerInfoAqua {
+    // Vec is a representation for Aqua optional values. This Vec always holds at most 1 element.
     timer: Vec<TimerEvent>,
+    // Vec is a representation for Aqua optional values. This Vec always holds at most 1 element.
     peer: Vec<PeerEvent>,
 }
 

--- a/crates/spell-event-bus/src/api.rs
+++ b/crates/spell-event-bus/src/api.rs
@@ -84,7 +84,7 @@ impl From<TriggerInfo> for TriggerInfoAqua {
                 peer: vec![], // Empty Vec corresponds to Aqua nil
             },
             TriggerInfo::Peer(p) => Self {
-                timer: vec![],
+                timer: vec![], // Empty Vec corresponds to Aqua nil
                 peer: vec![p],
             },
         }

--- a/crates/spell-event-bus/src/bus.rs
+++ b/crates/spell-event-bus/src/bus.rs
@@ -164,7 +164,7 @@ enum BusInternalError {
     #[error("failed to send a result of a command execution ({1:?}) for a spell {0}: receiving end probably dropped")]
     Reply(SpellId, Action),
     #[error("failed to send notification about a peer event {1:?} to spell {0}: {2}")]
-    SendEvent(SpellId, Event, SendError),
+    SendEvent(SpellId, TriggerInfo, SendError),
 }
 
 pub struct SpellEventBus {
@@ -246,7 +246,7 @@ impl SpellEventBus {
                     },
                     event = sources_channel.select_next_some() => {
                         for spell_id in state.subscribers(&event.get_type()) {
-                            let event = Event::Peer(event.clone());
+                            let event = TriggerInfo::Peer(event.clone());
                             Self::trigger_spell(&send_events, spell_id, event)?;
                         }
                     },
@@ -254,8 +254,8 @@ impl SpellEventBus {
                         // The timer is triggered only if there are some spells to be awaken.
                         if let Some(scheduled_spell) = state.scheduled.pop() {
                             log::trace!("Execute: {:?}", scheduled_spell);
-                            let timestamp_secs = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs();
-                            Self::trigger_spell(&send_events, &scheduled_spell.data.id, Event::Timer(timestamp_secs))?;
+                            let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs();
+                            Self::trigger_spell(&send_events, &scheduled_spell.data.id, TriggerInfo::Timer(TimerEvent{ timestamp }))?;
                             // Do not reschedule the spell otherwise.
                             if let Some(rescheduled) = Scheduled::at(scheduled_spell.data, Instant::now()) {
                                 log::trace!("Reschedule: {:?}", rescheduled);
@@ -274,12 +274,12 @@ impl SpellEventBus {
     fn trigger_spell(
         send_events: &Outlet<TriggerEvent>,
         id: &Arc<SpellId>,
-        event: Event,
+        event: TriggerInfo,
     ) -> Result<(), BusInternalError> {
         send_events
             .unbounded_send(TriggerEvent {
                 spell_id: (**id).clone(),
-                event: event.clone(),
+                info: event.clone(),
             })
             .map_err(|e| BusInternalError::SendEvent((**id).clone(), event, e.into_send_error()))?;
         Ok(())
@@ -313,16 +313,18 @@ mod tests {
     }
 
     fn send_connect_event(send: &Outlet<PeerEvent>, peer_id: PeerId) {
-        send.unbounded_send(PeerEvent::ConnectionPool(LifecycleEvent::Connected(
-            Contact::new(peer_id, Vec::new()),
-        )))
+        send.unbounded_send(PeerEvent::from(LifecycleEvent::Connected(Contact::new(
+            peer_id,
+            Vec::new(),
+        ))))
         .unwrap();
     }
 
     fn send_disconnect_event(send: &Outlet<PeerEvent>, peer_id: PeerId) {
-        send.unbounded_send(PeerEvent::ConnectionPool(LifecycleEvent::Disconnected(
-            Contact::new(peer_id, Vec::new()),
-        )))
+        send.unbounded_send(PeerEvent::from(LifecycleEvent::Disconnected(Contact::new(
+            peer_id,
+            Vec::new(),
+        ))))
         .unwrap();
     }
 
@@ -384,7 +386,7 @@ mod tests {
                 assert_eq!(events.len(), 5);
                 for event in events.into_iter() {
                     assert_eq!(event.spell_id, spell1_id.clone(),);
-                    assert_matches!(event.event, Event::Timer(_));
+                    assert_matches!(event.info, TriggerInfo::Timer(_));
                 }
             },
             || {
@@ -416,7 +418,7 @@ mod tests {
                 assert_eq!(events.len(), 10);
                 for event in events.into_iter() {
                     spell_ids.entry(event.spell_id).and_modify(|e| *e += 1);
-                    assert_matches!(event.event, Event::Timer(_));
+                    assert_matches!(event.info, TriggerInfo::Timer(_));
                 }
                 for count in spell_ids.values() {
                     assert_ne!(*count, 0);
@@ -480,10 +482,10 @@ mod tests {
         try_catch(
             || {
                 assert_eq!(event.spell_id, spell1_id.clone());
-                let expected = Contact::new(peer_id, Vec::new());
+                let expected = peer_id;
                 assert_matches!(
-                    event.event,
-                    Event::Peer(PeerEvent::ConnectionPool(LifecycleEvent::Connected(contact))) if contact == expected
+                    event.info,
+                    TriggerInfo::Peer(p) if p.peer_id == expected
                 );
             },
             || {
@@ -551,11 +553,11 @@ mod tests {
                     assert!(event.spell_id == spell1_id || event.spell_id == spell2_id);
                     if event.spell_id == spell1_id {
                         assert_matches!(
-                            event.event,
-                            Event::Peer(PeerEvent::ConnectionPool(LifecycleEvent::Connected(_)))
+                            event.info,
+                           TriggerInfo::Peer(p) if p.connected
                         );
                     } else if event.spell_id == spell2_id {
-                        assert_matches!(event.event, Event::Timer(_));
+                        assert_matches!(event.info, TriggerInfo::Timer(_));
                     }
                 }
             },
@@ -585,8 +587,8 @@ mod tests {
             let disconnect_event = event_stream.try_next();
             assert_eq!(connect_event.spell_id, spell1_id);
             assert_matches!(
-                connect_event.event,
-                Event::Peer(PeerEvent::ConnectionPool(LifecycleEvent::Connected(_)))
+                connect_event.info,
+                TriggerInfo::Peer(p) if p.connected
             );
             assert!(
                 disconnect_event.is_err(),
@@ -606,8 +608,8 @@ mod tests {
             let connect_event = event_stream.try_next();
             assert_eq!(disconnect_event.spell_id, spell1_id);
             assert_matches!(
-                disconnect_event.event,
-                Event::Peer(PeerEvent::ConnectionPool(LifecycleEvent::Disconnected(_)))
+                disconnect_event.info,
+                TriggerInfo::Peer(p) if !p.connected
             );
             assert!(
                 connect_event.is_err(),

--- a/crates/spell-event-bus/src/bus.rs
+++ b/crates/spell-event-bus/src/bus.rs
@@ -384,7 +384,7 @@ mod tests {
                 assert_eq!(events.len(), 5);
                 for event in events.into_iter() {
                     assert_eq!(event.spell_id, spell1_id.clone(),);
-                    assert_matches!(event.event, Event::Timer);
+                    assert_matches!(event.event, Event::Timer(_));
                 }
             },
             || {
@@ -416,7 +416,7 @@ mod tests {
                 assert_eq!(events.len(), 10);
                 for event in events.into_iter() {
                     spell_ids.entry(event.spell_id).and_modify(|e| *e += 1);
-                    assert_matches!(event.event, Event::Timer);
+                    assert_matches!(event.event, Event::Timer(_));
                 }
                 for count in spell_ids.values() {
                     assert_ne!(*count, 0);
@@ -555,7 +555,7 @@ mod tests {
                             Event::Peer(PeerEvent::ConnectionPool(LifecycleEvent::Connected(_)))
                         );
                     } else if event.spell_id == spell2_id {
-                        assert_matches!(event.event, Event::Timer);
+                        assert_matches!(event.event, Event::Timer(_));
                     }
                 }
             },

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -224,7 +224,7 @@ impl<RT: AquaRuntime> Node<RT> {
 
         let recv_connection_pool_events = connectivity.connection_pool.lifecycle_events();
         let sources = vec![recv_connection_pool_events
-            .map(|x| PeerEvent::ConnectionPool(x))
+            .map(|x| PeerEvent::from(x))
             .boxed()];
 
         let (spell_event_bus, spell_event_bus_api, spell_events_stream) =

--- a/particle-node/tests/spells.rs
+++ b/particle-node/tests/spells.rs
@@ -813,3 +813,97 @@ fn spell_update_config() {
         assert_eq!(x, "called", "spell must be triggered after config update");
     }
 }
+
+#[test]
+fn spell_timer_trigger_mailbox_test() {
+    let swarms = make_swarms(1);
+    let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
+        .wrap_err("connect client")
+        .unwrap();
+
+    let script = format!(
+        r#"
+        (seq
+            (seq
+                (call %init_peer_id% ("getDataSrv" "spell_id") [] spell_id)
+                (call %init_peer_id% (spell_id "list_pop_string") ["trigger_mailbox"] trigger)
+            )
+            (seq
+                (call %init_peer_id% ("json" "parse") [trigger.$.str] obj)
+                (call "{}" ("return" "") [obj])
+            )
+        )
+    "#,
+        client.peer_id
+    );
+
+    let mut config = TriggerConfig::default();
+    config.clock.period_sec = 0;
+    config.clock.start_sec = 1;
+    create_spell(&mut client, &script, config, hashmap! {});
+
+    let value = client.receive_args().wrap_err("receive").unwrap()[0]
+        .as_object()
+        .cloned()
+        .unwrap();
+
+    assert!(value.contains_key("peer"));
+    assert!(value.contains_key("timer"));
+    assert_eq!(value["peer"].as_array().unwrap().len(), 0);
+    let timer_opt = value["timer"].as_array().cloned().unwrap();
+    assert_eq!(timer_opt.len(), 1);
+    let timer = timer_opt[0].as_object().cloned().unwrap();
+    assert!(timer.contains_key("timestamp"));
+    assert!(timer["timestamp"].as_i64().unwrap() > 0);
+}
+
+#[test]
+fn spell_connection_pool_trigger_mailbox_test() {
+    let swarms = make_swarms(1);
+    let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
+        .wrap_err("connect client")
+        .unwrap();
+
+    let script = format!(
+        r#"
+        (seq
+            (seq
+                (call %init_peer_id% ("getDataSrv" "spell_id") [] spell_id)
+                (call %init_peer_id% (spell_id "list_pop_string") ["trigger_mailbox"] trigger)
+            )
+            (seq
+                (call %init_peer_id% ("json" "parse") [trigger.$.str] obj)
+                (call "{}" ("return" "") [obj])
+            )
+        )
+    "#,
+        client.peer_id
+    );
+
+    let mut config = TriggerConfig::default();
+    config.connections.disconnect = true;
+    create_spell(&mut client, &script, config.clone(), hashmap! {});
+
+    let disconnected_client = ConnectedClient::connect_to(swarms[0].multiaddr.clone()).unwrap();
+    let disconnected_client_peer_id = disconnected_client.peer_id;
+    disconnected_client.client.stop();
+
+    let value = client.receive_args().wrap_err("receive").unwrap()[0]
+        .as_object()
+        .cloned()
+        .unwrap();
+
+    assert!(value.contains_key("peer"));
+    assert!(value.contains_key("timer"));
+    assert_eq!(value["timer"].as_array().unwrap().len(), 0);
+    let peer_opt = value["peer"].as_array().cloned().unwrap();
+    assert_eq!(peer_opt.len(), 1);
+    let peer = peer_opt[0].as_object().cloned().unwrap();
+    assert!(peer.contains_key("peer_id"));
+    assert!(peer.contains_key("connected"));
+    assert_eq!(
+        peer["peer_id"].as_str().unwrap(),
+        disconnected_client_peer_id.to_base58()
+    );
+    assert!(!peer["connected"].as_bool().unwrap());
+}

--- a/sorcerer/src/sorcerer.rs
+++ b/sorcerer/src/sorcerer.rs
@@ -125,7 +125,7 @@ impl Sorcerer {
                     let sorcerer = self.clone();
                     // Note that the event that triggered the spell is in `spell_event.event`
                     async move {
-                        sorcerer.execute_script(spell_event.spell_id).await;
+                        sorcerer.execute_script(spell_event).await;
                     }
                 })
                 .await;


### PR DESCRIPTION
Trigger info is stored in spell KV storage by the "trigger_mailbox" key and can be obtained via `spell.list_pop_string`

The next code should be put in aqua-lib:
```
data TimerTrigger:
  timestamp: u64

data PeerTrigger:
  peer_id: PeerId
  connected: boolean

data TriggerEvent:
  timer: ?TimerTrigger
  peer: ?PeerTrigger

service TriggerEventJson:
  parse(s: string) -> TriggerEvent

func get_trigger() -> TriggerEvent:
  s <- Spell.list_pop_string("trigger_mailbox)
  trigger <- TriggerEventJson.parse(s)

  <- trigger
```

