### PR TITLE
feat(spells): do json manipulations internally

### DIFF
--- a/sorcerer/src/spells.rs
+++ b/sorcerer/src/spells.rs
@@ -279,8 +279,7 @@ pub(crate) fn store_response(
     .map(drop)
     .map_err(|e| {
         JError::new(format!(
-            "Failed to store response {:?} for spell {}: {}",
-            response, spell_id, e
+            "Failed to store response {response} for spell {spell_id}: {e}"
         ))
     })
 }


### PR DESCRIPTION
- spell's `getDataSrv` returns parsed json value, so there is no need to parse it manually
- `spell.install` now accepts any object as `init_data` (previously, it was accepting only stringified ones)
- spell's `response` accepts objects (previously, it was accepting only stringified ones)