### PR TITLE
feat(builtins): json.obj_pairs, json.puts_pairs to build JSON objects from array of pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,8 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "fluence-keypair"
-version = "0.8.1"
-source = "git+https://github.com/fluencelabs/trust-graph?branch=update_libp2p#1e9f27cd1db6793fa76577651dc19f74ea450b61"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fcc75906f1ce92beb78826efe2a02ee92089d853c3276bece83c629024b1c72"
 dependencies = [
  "asn1_der 0.6.3",
  "bs58 0.3.1",

--- a/crates/json-utils/src/lib.rs
+++ b/crates/json-utils/src/lib.rs
@@ -25,8 +25,6 @@
     unreachable_patterns
 )]
 
-use std::fmt::Display;
-
 use serde_json::Value as JValue;
 
 pub mod base64_serde;
@@ -48,6 +46,6 @@ pub fn into_array(v: JValue) -> Option<Vec<JValue>> {
 }
 
 /// Converts an error into IValue::String
-pub fn err_as_value<E: Display>(err: E) -> JValue {
-    JValue::String(format!("Error: {err}"))
+pub fn err_as_value<E: core::fmt::Debug>(err: E) -> JValue {
+    JValue::String(format!("Error: {err:?}"))
 }

--- a/crates/json-utils/src/lib.rs
+++ b/crates/json-utils/src/lib.rs
@@ -46,6 +46,6 @@ pub fn into_array(v: JValue) -> Option<Vec<JValue>> {
 }
 
 /// Converts an error into IValue::String
-pub fn err_as_value<E: core::fmt::Debug>(err: E) -> JValue {
-    JValue::String(format!("Error: {err:?}"))
+pub fn err_as_value<E: core::fmt::Debug + core::fmt::Display>(err: E) -> JValue {
+    JValue::String(format!("Error: {err}\n{err:?}"))
 }

--- a/crates/log-utils/src/lib.rs
+++ b/crates/log-utils/src/lib.rs
@@ -19,11 +19,11 @@
 pub fn enable_logs() {
     use log::LevelFilter::*;
 
-    std::env::set_var("WASM_LOG", "trace");
+    std::env::set_var("WASM_LOG", "info");
 
     env_logger::builder()
         .format_timestamp_millis()
-        .filter_level(log::LevelFilter::Off)
+        .filter_level(log::LevelFilter::Info)
         .filter(Some("script_storage"), Trace)
         .filter(Some("script_storage"), Trace)
         .filter(Some("sorcerer"), Trace)

--- a/crates/particle-args/src/args_error.rs
+++ b/crates/particle-args/src/args_error.rs
@@ -16,6 +16,7 @@
 
 use json_utils::err_as_value;
 
+use eyre::Report;
 use serde_json::{json, Value as JValue};
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
@@ -65,6 +66,10 @@ impl Display for JError {
 impl JError {
     pub fn new(msg: impl AsRef<str>) -> Self {
         Self(json!(msg.as_ref()))
+    }
+
+    pub fn from_eyre(err: Report) -> Self {
+        JError(err_as_value(err))
     }
 }
 

--- a/crates/particle-node-tests/tests/script_storage.rs
+++ b/crates/particle-node-tests/tests/script_storage.rs
@@ -693,6 +693,11 @@ fn add_script_from_vault_wrong_vault() {
         .as_slice()
     {
         let expected_error_prefix = "Local service error, ret_code is 1, error message is '\"Error: Incorrect vault path `/tmp/vault/another-particle-id/script";
-        assert!(error_msg.starts_with(expected_error_prefix));
+        assert!(
+            error_msg.starts_with(expected_error_prefix),
+            "expected:\n{}\ngot:\n{}",
+            expected_error_prefix,
+            error_msg
+        );
     }
 }

--- a/crates/particle-node-tests/tests/script_storage.rs
+++ b/crates/particle-node-tests/tests/script_storage.rs
@@ -695,9 +695,7 @@ fn add_script_from_vault_wrong_vault() {
         let expected_error_prefix = "Local service error, ret_code is 1, error message is '\"Error: Incorrect vault path `/tmp/vault/another-particle-id/script";
         assert!(
             error_msg.starts_with(expected_error_prefix),
-            "expected:\n{}\ngot:\n{}",
-            expected_error_prefix,
-            error_msg
+            "expected:\n{expected_error_prefix}\ngot:\n{error_msg}"
         );
     }
 }

--- a/crates/particle-node-tests/tests/spells.rs
+++ b/crates/particle-node-tests/tests/spells.rs
@@ -25,6 +25,7 @@ use serde_json::{json, Value as JValue};
 use connected_client::ConnectedClient;
 use created_swarm::make_swarms;
 use fluence_spell_dtos::trigger_config::TriggerConfig;
+use log_utils::enable_logs;
 use service_modules::load_module;
 use spell_event_bus::api::{TriggerInfo, TriggerInfoAqua, MAX_PERIOD_SEC};
 use test_utils::create_service;
@@ -426,6 +427,8 @@ fn spell_install_fail_end_sec_past() {
 // In this case we don't schedule a spell and return error.
 #[test]
 fn spell_install_fail_end_sec_before_start() {
+    enable_logs();
+
     let swarms = make_swarms(1);
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())
         .wrap_err("connect client")

--- a/crates/particle-node-tests/tests/spells.rs
+++ b/crates/particle-node-tests/tests/spells.rs
@@ -414,8 +414,11 @@ fn spell_install_fail_end_sec_past() {
         .unwrap()
         .as_slice()
     {
-        let msg = "Local service error, ret_code is 1, error message is '\"Error: invalid config: end_sec is less than start_sec or in the past\"'";
-        assert!(error_msg.starts_with(msg));
+        let expected = "Local service error, ret_code is 1, error message is '\"Error: invalid config: end_sec is less than start_sec or in the past";
+        assert!(
+            error_msg.starts_with(expected),
+            "expected:\n{expected}\ngot:\n{error_msg}"
+        );
     }
 }
 
@@ -463,8 +466,11 @@ fn spell_install_fail_end_sec_before_start() {
         .unwrap()
         .as_slice()
     {
-        let msg = "Local service error, ret_code is 1, error message is '\"Error: invalid config: end_sec is less than start_sec or in the past\"'";
-        assert!(error_msg.starts_with(msg));
+        let expected = "Local service error, ret_code is 1, error message is '\"Error: invalid config: end_sec is less than start_sec or in the past";
+        assert!(
+            error_msg.starts_with(expected),
+            "expected:\n{expected}\ngot:\n{error_msg}"
+        );
     }
 }
 
@@ -601,10 +607,10 @@ fn spell_remove_spell_as_service() {
         .unwrap()
         .as_slice()
     {
-        let msg_end = "cannot call function 'remove_service': cannot remove a spell\"'";
+        let expected = "cannot call function 'remove_service': cannot remove a spell";
         assert!(
-            msg.ends_with(msg_end),
-            "should end with `{msg_end}`, given msg `{msg}`"
+            msg.contains(expected),
+            "should contain `{expected}`, given msg `{msg}`"
         );
     }
 }
@@ -644,10 +650,10 @@ fn spell_remove_service_as_spell() {
         .unwrap()
         .as_slice()
     {
-        let msg_end = "cannot call function 'remove_spell': the service isn't a spell\"'";
+        let expected = "cannot call function 'remove_spell': the service isn't a spell";
         assert!(
-            msg.ends_with(msg_end),
-            "should end with `{msg_end}`, given msg `{msg}`"
+            msg.contains(expected),
+            "should contain `{expected}`, given msg `{msg}`"
         );
     }
 }

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -256,8 +256,8 @@ where
             ("json", "puts")       => wrap(json::puts(args)),
             ("json", "parse")      => unary(args, |s: String| -> R<JValue, _> { json::parse(&s) }),
             ("json", "stringify")  => unary(args, |v: JValue| -> R<String, _> { Ok(json::stringify(v)) }),
-            ("json", "obj_array") => unary(args, |vs: Vec<JValue>| -> R<JValue, _> { json::obj_from_array(vs) }),
-            ("json", "puts_array") => binary(args, |obj: JValue, vs: Vec<JValue>| -> R<JValue, _> { json::puts_from_array(obj, vs) }),
+            ("json", "obj_pairs") => unary(args, |vs: Vec<(String, JValue)>| -> R<JValue, _> { json::obj_from_pairs(vs) }),
+            ("json", "puts_pairs") => binary(args, |obj: JValue, vs: Vec<JValue>| -> R<JValue, _> { json::puts_from_array(obj, vs) }),
 
             _                      => FunctionOutcome::NotDefined { args, params: particle },
         }

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -255,7 +255,7 @@ where
             ("json", "puts")       => wrap(json::puts(args)),
             ("json", "parse")      => unary(args, |s: String| -> R<JValue, _> { json::parse(&s) }),
             ("json", "stringify")  => unary(args, |v: JValue| -> R<String, _> { Ok(json::stringify(v)) }),
-            ("json", "obj_pairs") => unary(args, |vs: Vec<(String, JValue)>| -> R<JValue, _> { json::obj_from_pairs(vs) }),
+            ("json", "obj_pairs")  => unary(args, |vs: Vec<(String, JValue)>| -> R<JValue, _> { json::obj_from_pairs(vs) }),
             ("json", "puts_pairs") => binary(args, |obj: JValue, vs: Vec<(String, JValue)>| -> R<JValue, _> { json::puts_from_pairs(obj, vs) }),
 
             ("run-console", "print") => wrap_unit(Ok(log::debug!(target: "run-console", "{}", json!(args.function_args)))),

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -256,6 +256,8 @@ where
             ("json", "puts")       => wrap(json::puts(args)),
             ("json", "parse")      => unary(args, |s: String| -> R<JValue, _> { json::parse(&s) }),
             ("json", "stringify")  => unary(args, |v: JValue| -> R<String, _> { Ok(json::stringify(v)) }),
+            ("json", "obj_array") => unary(args, |vs: Vec<JValue>| -> R<JValue, _> { json::obj_from_array(vs) }),
+            ("json", "puts_array") => binary(args, |obj: JValue, vs: Vec<JValue>| -> R<JValue, _> { json::puts_from_array(obj, vs) }),
 
             _                      => FunctionOutcome::NotDefined { args, params: particle },
         }

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -258,7 +258,7 @@ where
             ("json", "obj_pairs") => unary(args, |vs: Vec<(String, JValue)>| -> R<JValue, _> { json::obj_from_pairs(vs) }),
             ("json", "puts_pairs") => binary(args, |obj: JValue, vs: Vec<(String, JValue)>| -> R<JValue, _> { json::puts_from_pairs(obj, vs) }),
 
-            ("run-console", "print") => wrap_unit(Ok(log::info!("{}", json!(args.function_args)))),
+            ("run-console", "print") => wrap_unit(Ok(log::debug!(target: "run-console", "{}", json!(args.function_args)))),
 
             _                      => FunctionOutcome::NotDefined { args, params: particle },
         }

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -257,7 +257,9 @@ where
             ("json", "parse")      => unary(args, |s: String| -> R<JValue, _> { json::parse(&s) }),
             ("json", "stringify")  => unary(args, |v: JValue| -> R<String, _> { Ok(json::stringify(v)) }),
             ("json", "obj_pairs") => unary(args, |vs: Vec<(String, JValue)>| -> R<JValue, _> { json::obj_from_pairs(vs) }),
-            ("json", "puts_pairs") => binary(args, |obj: JValue, vs: Vec<JValue>| -> R<JValue, _> { json::puts_from_array(obj, vs) }),
+            ("json", "puts_pairs") => binary(args, |obj: JValue, vs: Vec<(String, JValue)>| -> R<JValue, _> { json::puts_from_pairs(obj, vs) }),
+
+            ("run-console", "print") => wrap_unit(Ok(log::info!("{}", json!(args.function_args)))),
 
             _                      => FunctionOutcome::NotDefined { args, params: particle },
         }

--- a/particle-builtins/src/json.rs
+++ b/particle-builtins/src/json.rs
@@ -76,7 +76,7 @@ pub fn puts_from_pairs(
     object: JValue,
     values: impl IntoIterator<Item = (String, JValue)>,
 ) -> Result<JValue, JError> {
-    if let JValue::Object(map) = object {
+    if let JValue::Object(map) = object.clone() {
         let map = values.into_iter().fold(map, |mut acc, (k, v)| {
             acc.insert(k, v);
             acc

--- a/particle-builtins/src/json.rs
+++ b/particle-builtins/src/json.rs
@@ -83,14 +83,14 @@ pub fn puts_from_pairs(
         });
         Ok(JValue::Object(map))
     } else {
-        Err(JError::new(format!("expected json object, got {}", object)))
+        Err(JError::new(format!("expected json object, got {object}")))
     }
 }
 
 pub fn parse(json: &str) -> Result<JValue, JError> {
     serde_json::from_str(json)
         .context(format!("error parsing json {json}"))
-        .map_err(|err| JError::new(format!("{:?}", err)))
+        .map_err(JError::from_eyre)
 }
 
 pub fn stringify(value: JValue) -> String {

--- a/particle-builtins/src/json.rs
+++ b/particle-builtins/src/json.rs
@@ -35,10 +35,18 @@ pub fn obj(args: Args) -> Result<JValue, JError> {
 }
 
 /// Constructs a JSON object from a list of key value pairs.
-pub fn obj_from_array(values: impl IntoIterator<Item = JValue>) -> Result<JValue, JError> {
-    let object = obj_from_iter(<_>::default(), &mut values.into_iter())?;
+pub fn obj_from_pairs(
+    values: impl IntoIterator<Item = (String, JValue)>,
+) -> Result<JValue, JError> {
+    let map = values.into_iter().fold(
+        <serde_json::Map<String, JValue>>::default(),
+        |mut acc, (k, v)| {
+            acc.insert(k, v);
+            acc
+        },
+    );
 
-    Ok(JValue::Object(object))
+    Ok(JValue::Object(map))
 }
 
 /// Inserts a value into a JSON object


### PR DESCRIPTION
`json.obj` and `json.puts` are basically varargs, which gives flexibility, but is impossible to express in well-typed Aqua.

`json.obj` allows to build JSON object from an array of `(string, json)` pairs.