### PR TITLE
fix(spells): do not run spells with passed (ended) Clock trigger

### DIFF
--- a/crates/spell-event-bus/src/config.rs
+++ b/crates/spell-event-bus/src/config.rs
@@ -121,7 +121,7 @@ impl SpellTriggerConfigs {
             .into_iter()
             .filter_map(|trigger| trigger.into_rescheduled())
             .collect::<_>();
-        if new_triggers.len() == 0 {
+        if new_triggers.is_empty() {
             None
         } else {
             Some(SpellTriggerConfigs {
@@ -140,7 +140,7 @@ pub(crate) enum TriggerConfig {
 impl TriggerConfig {
     pub fn into_rescheduled(self) -> Option<TriggerConfig> {
         if let TriggerConfig::Timer(c) = self {
-            c.into_rescheduled().map(|x| TriggerConfig::Timer(x))
+            c.into_rescheduled().map(TriggerConfig::Timer)
         } else {
             // Peer events can't stop being relevant
             Some(self)

--- a/sorcerer/src/sorcerer.rs
+++ b/sorcerer/src/sorcerer.rs
@@ -119,10 +119,12 @@ impl Sorcerer {
                     "get_trigger_config",
                 )?;
                 let config = from_user_config(result.config)?;
-                if let Some(config) = config {
+                if let Some(config) = config.and_then(|c| c.into_rescheduled()) {
                     self.spell_event_bus_api
                         .subscribe(spell_id.clone(), config.clone())
                         .await?;
+                } else {
+                    log::warn!("Spell {spell_id} is not rescheduled since its config is either not found or not reschedulable");
                 }
             };
             if let Err(e) = result {


### PR DESCRIPTION
Right now _all_ spells will be rerun after the node restart, even the ones that ended before restarting. 

So the new rule is:  _the spell won't be restarted if in its trigger config `end_at <= now` or it's a one-shot spell that started in the past_.

Not sure about the following events:
1. The spell is a one-shot that should be run immediately or was running, but the node was restarted during the process.
2. The periodic spell with `end_at` was added, then the node was shut down until `end_at`, so the spell was never executed.

These events don't seem to be very relevant though. 
 