### PR TITLE
fix: collect separate metrics for root alised services and worker spells [fixes NET-431]

### DIFF
--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -383,7 +383,17 @@ impl ParticleAppServices {
         //     ));
         // }
 
-        let service_type = ServiceType::Service(service.aliases.first().cloned());
+        // Metrics collection are enables for services with aliases which are installed on root worker or worker spells.
+        let allowed_alias = if worker_id == self.config.local_peer_id {
+            service.aliases.first().cloned()
+        } else {
+            if service.aliases.iter().any(|alias| alias == "worker-spell") {
+                Some("worker-spell".to_string())
+            } else {
+                None
+            }
+        };
+        let service_type = ServiceType::Service(allowed_alias);
 
         // TODO: move particle vault creation to aquamarine::particle_functions
         self.create_vault(&particle.id)?;


### PR DESCRIPTION
Collect separate metrics for:
- aliased services from root scope
- worker spells (aka marked as such in aliases)