### PR TITLE
feat: extend peer identify with spell service version and allowed mounted binaries list [fixes NET-429 NET-381]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4406,6 +4406,7 @@ dependencies = [
  "eyre",
  "fluence-keypair",
  "fluence-libp2p",
+ "fluence-spell-distro",
  "fs-utils",
  "fstrings",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4406,7 +4406,6 @@ dependencies = [
  "eyre",
  "fluence-keypair",
  "fluence-libp2p",
- "fluence-spell-distro",
  "fs-utils",
  "fstrings",
  "futures",

--- a/particle-builtins/src/builtins.rs
+++ b/particle-builtins/src/builtins.rs
@@ -51,7 +51,6 @@ use crate::debug::fmt_custom_services;
 use crate::error::HostClosureCallError;
 use crate::error::HostClosureCallError::{DecodeBase58, DecodeUTF8};
 use crate::func::{binary, unary};
-use crate::identify::NodeInfo;
 use crate::outcome::{ok, wrap, wrap_unit};
 use crate::{json, math};
 
@@ -87,8 +86,6 @@ pub struct Builtins<C> {
 
     pub modules: ModuleRepository,
     pub services: ParticleAppServices,
-    pub node_info: NodeInfo,
-
     #[derivative(Debug(format_with = "fmt_custom_services"))]
     pub custom_services: RwLock<HashMap<String, CustomService>>,
 
@@ -105,7 +102,6 @@ where
     pub fn new(
         connectivity: C,
         script_storage: ScriptStorageApi,
-        node_info: NodeInfo,
         config: ServicesConfig,
         services_metrics: ServicesMetrics,
         key_manager: KeyManager,
@@ -135,7 +131,6 @@ where
             local_peer_id,
             modules,
             services,
-            node_info,
             particles_vault_dir,
             custom_services: <_>::default(),
             key_manager,
@@ -191,7 +186,6 @@ where
 
         #[rustfmt::skip]
         match (args.service_id.as_str(), args.function_name.as_str()) {
-            ("peer", "identify") => ok(json!(self.node_info)),
             ("peer", "timestamp_ms") => ok(json!(now_ms() as u64)),
             ("peer", "timestamp_sec") => ok(json!(now_sec())),
             ("peer", "is_connected") => wrap(self.is_connected(args).await),

--- a/particle-builtins/src/identify.rs
+++ b/particle-builtins/src/identify.rs
@@ -22,4 +22,6 @@ pub struct NodeInfo {
     pub external_addresses: Vec<Multiaddr>,
     pub node_version: &'static str,
     pub air_version: &'static str,
+    pub spell_version: &'static str,
+    pub allowed_binaries: Vec<String>,
 }

--- a/particle-builtins/src/identify.rs
+++ b/particle-builtins/src/identify.rs
@@ -22,6 +22,6 @@ pub struct NodeInfo {
     pub external_addresses: Vec<Multiaddr>,
     pub node_version: &'static str,
     pub air_version: &'static str,
-    pub spell_version: &'static str,
+    pub spell_version: String,
     pub allowed_binaries: Vec<String>,
 }

--- a/particle-node/Cargo.toml
+++ b/particle-node/Cargo.toml
@@ -17,7 +17,6 @@ script-storage = { workspace = true }
 aquamarine = { workspace = true }
 sorcerer = { workspace = true }
 dhat = { version = "0.3.2", optional = true }
-fluence-spell-distro = { workspace = true }
 
 
 serde_json = { workspace = true }

--- a/particle-node/Cargo.toml
+++ b/particle-node/Cargo.toml
@@ -17,6 +17,7 @@ script-storage = { workspace = true }
 aquamarine = { workspace = true }
 sorcerer = { workspace = true }
 dhat = { version = "0.3.2", optional = true }
+fluence-spell-distro = { workspace = true }
 
 
 fluence-libp2p = { workspace = true }

--- a/particle-node/Cargo.toml
+++ b/particle-node/Cargo.toml
@@ -20,6 +20,7 @@ dhat = { version = "0.3.2", optional = true }
 fluence-spell-distro = { workspace = true }
 
 
+serde_json = { workspace = true }
 fluence-libp2p = { workspace = true }
 server-config = { workspace = true }
 config-utils = { workspace = true }

--- a/particle-node/src/builtins.rs
+++ b/particle-node/src/builtins.rs
@@ -1,0 +1,20 @@
+use futures::FutureExt;
+use particle_builtins::{ok, CustomService, NodeInfo};
+use particle_execution::ServiceFunction;
+use serde_json::json;
+
+pub fn make_peer_builtin(node_info: NodeInfo) -> (String, CustomService) {
+    (
+        "peer".to_string(),
+        CustomService::new(
+            vec![("identify", make_peer_identify_closure(node_info))],
+            None,
+        ),
+    )
+}
+fn make_peer_identify_closure(node_info: NodeInfo) -> ServiceFunction {
+    ServiceFunction::Immut(Box::new(move |_args, _params| {
+        let node_info = node_info.clone();
+        async move { ok(json!(node_info)) }.boxed()
+    }))
+}

--- a/particle-node/src/builtins.rs
+++ b/particle-node/src/builtins.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use futures::FutureExt;
 use particle_builtins::{ok, CustomService, NodeInfo};
 use particle_execution::ServiceFunction;

--- a/particle-node/src/lib.rs
+++ b/particle-node/src/lib.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![feature(extend_one)]
 #![feature(try_blocks)]
 #![feature(drain_filter)]
 #![feature(ip)]
@@ -28,6 +29,7 @@
     unreachable_patterns
 )]
 
+mod builtins;
 mod connectivity;
 mod dispatcher;
 mod effectors;

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -327,6 +327,12 @@ impl<RT: AquaRuntime> Node<RT> {
             external_addresses,
             node_version: env!("CARGO_PKG_VERSION"),
             air_version: air_interpreter_wasm::VERSION,
+            spell_version: fluence_spell_distro::VERSION,
+            allowed_binaries: services_config
+                .allowed_binaries
+                .iter()
+                .map(|s| s.to_string_lossy().to_string())
+                .collect::<_>(),
         };
 
         Builtins::new(

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -249,7 +249,7 @@ impl<RT: AquaRuntime> Node<RT> {
         let (spell_event_bus, spell_event_bus_api, spell_events_receiver) =
             SpellEventBus::new(sources);
 
-        let (sorcerer, mut spell_service_functions, spell_version) = Sorcerer::new(
+        let (sorcerer, mut custom_service_functions, spell_version) = Sorcerer::new(
             builtins.services.clone(),
             builtins.modules.clone(),
             aquamarine_api.clone(),
@@ -265,9 +265,9 @@ impl<RT: AquaRuntime> Node<RT> {
             spell_version,
             allowed_binaries,
         };
-        spell_service_functions.extend_one(make_peer_builtin(node_info));
+        custom_service_functions.extend_one(make_peer_builtin(node_info));
 
-        spell_service_functions.into_iter().for_each(
+        custom_service_functions.into_iter().for_each(
             move |(
                 service_id,
                 CustomService {

--- a/sorcerer/src/sorcerer.rs
+++ b/sorcerer/src/sorcerer.rs
@@ -19,7 +19,6 @@ use std::time::Duration;
 
 use fluence_spell_dtos::trigger_config::TriggerConfigValue;
 use futures::{FutureExt, StreamExt};
-use serde_json::json;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -33,7 +32,7 @@ use crate::worker_builins::{create_worker, get_worker_peer_id, remove_worker, wo
 use aquamarine::AquamarineApi;
 use key_manager::KeyManager;
 use particle_args::JError;
-use particle_builtins::{ok, wrap, wrap_unit, CustomService, NodeInfo};
+use particle_builtins::{wrap, wrap_unit, CustomService};
 use particle_execution::ServiceFunction;
 use particle_modules::ModuleRepository;
 use particle_services::ParticleAppServices;
@@ -60,12 +59,10 @@ impl Sorcerer {
         config: ResolvedConfig,
         spell_event_bus_api: SpellEventBusApi,
         key_manager: KeyManager,
-        mut node_info: NodeInfo,
-    ) -> (Self, HashMap<String, CustomService>) {
+    ) -> (Self, HashMap<String, CustomService>, String) {
         let (spell_storage, spell_version) =
             SpellStorage::create(&config.dir_config.spell_base_dir, &services, &modules)
                 .expect("Spell storage creation");
-        node_info.spell_version = spell_version;
 
         let sorcerer = Self {
             aquamarine,
@@ -78,9 +75,8 @@ impl Sorcerer {
 
         let mut builtin_functions = sorcerer.make_spell_builtins();
         builtin_functions.extend_one(sorcerer.make_worker_builtin());
-        builtin_functions.extend_one(sorcerer.make_peer_builtin(node_info));
 
-        (sorcerer, builtin_functions)
+        (sorcerer, builtin_functions, spell_version)
     }
 
     async fn resubscribe_spells(&self) {
@@ -350,22 +346,6 @@ impl Sorcerer {
                 wrap_unit(remove_worker(args, params, key_manager, services, storage, api).await)
             }
             .boxed()
-        }))
-    }
-
-    fn make_peer_builtin(&self, node_info: NodeInfo) -> (String, CustomService) {
-        (
-            "peer".to_string(),
-            CustomService::new(
-                vec![("identify", self.make_peer_identify_closure(node_info))],
-                None,
-            ),
-        )
-    }
-    fn make_peer_identify_closure(&self, node_info: NodeInfo) -> ServiceFunction {
-        ServiceFunction::Immut(Box::new(move |_args, _params| {
-            let node_info = node_info.clone();
-            async move { ok(json!(node_info)) }.boxed()
         }))
     }
 }

--- a/spell-storage/src/storage.rs
+++ b/spell-storage/src/storage.rs
@@ -30,7 +30,6 @@ impl SpellStorage {
         services: &ParticleAppServices,
         modules: &ModuleRepository,
     ) -> eyre::Result<Self> {
-        log::info!("creating spell storage");
         let spell_config_path = spell_config_path(spells_base_dir);
         let spell_blueprint_id = if spell_config_path.exists() {
             let cfg = TomlMarineConfig::load(spell_config_path)?;
@@ -48,7 +47,6 @@ impl SpellStorage {
 
     fn load_spell_service_from_crate(modules: &ModuleRepository) -> eyre::Result<String> {
         use fluence_spell_distro::{modules as spell_modules, CONFIG};
-        log::info!("load from crate");
 
         log::info!(
             "Spell service impl version: {}",
@@ -78,7 +76,6 @@ impl SpellStorage {
         spells_base_dir: &Path,
         modules: &ModuleRepository,
     ) -> eyre::Result<String> {
-        log::info!("load from disk");
         let mut hashes = Vec::new();
         for config in cfg.module {
             let load_from = config

--- a/spell-storage/src/storage.rs
+++ b/spell-storage/src/storage.rs
@@ -30,6 +30,7 @@ impl SpellStorage {
         services: &ParticleAppServices,
         modules: &ModuleRepository,
     ) -> eyre::Result<Self> {
+        log::info!("creating spell storage");
         let spell_config_path = spell_config_path(spells_base_dir);
         let spell_blueprint_id = if spell_config_path.exists() {
             let cfg = TomlMarineConfig::load(spell_config_path)?;
@@ -47,6 +48,7 @@ impl SpellStorage {
 
     fn load_spell_service_from_crate(modules: &ModuleRepository) -> eyre::Result<String> {
         use fluence_spell_distro::{modules as spell_modules, CONFIG};
+        log::info!("load from crate");
 
         log::info!(
             "Spell service impl version: {}",
@@ -76,6 +78,7 @@ impl SpellStorage {
         spells_base_dir: &Path,
         modules: &ModuleRepository,
     ) -> eyre::Result<String> {
+        log::info!("load from disk");
         let mut hashes = Vec::new();
         for config in cfg.module {
             let load_from = config


### PR DESCRIPTION
Extend `Peer.identify`
* add list of `allowed_binaries`
* add `spell_version`

Looks like this
```json
{
  "air_version": "0.38.0",
  "allowed_binaries": [
    "/usr/bin/ipfs",
    "/usr/bin/curl"
  ],
  "external_addresses": [],
  "node_version": "0.9.1",
  "spell_version": "0.5.6"
}
```

Spell version is determent as follows:
1. If it's loaded from crate, the crate version is in use.
2. If it's loaded from disk, version is in the format `wasm hashes <hash1[..8]> <hash2[..8]>` with first 8 symbols of each hash.

To do this, I needed to move `Peer.identify` implementation from builtins to the sorcerer. Can't say I like it very much, but it works. 