### PR TITLE
feat: collect metrics for spell particles separately [fixes NET-439]

### DIFF
--- a/connection-pool/src/behaviour.rs
+++ b/connection-pool/src/behaviour.rs
@@ -566,9 +566,11 @@ impl NetworkBehaviour for ConnectionPoolBehaviour {
             HandlerMessage::InParticle(particle) => {
                 log::trace!(target: "network", "{}: received particle {} from {}; queue {}", self.peer_id, particle.id, from, self.queue.len());
                 self.meter(|m| {
-                    m.particle_queue_size.set(self.queue.len() as i64 + 1);
-                    m.received_particles.inc();
-                    m.particle_sizes.observe(particle.data.len() as f64);
+                    m.incoming_particle(
+                        &particle.id,
+                        self.queue.len() as i64 + 1,
+                        particle.data.len() as f64,
+                    )
                 });
                 self.queue.push_back(particle);
                 self.wake();

--- a/crates/peer-metrics/src/dispatcher.rs
+++ b/crates/peer-metrics/src/dispatcher.rs
@@ -1,9 +1,11 @@
+use crate::{ParticleLabel, ParticleType};
 use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
 use prometheus_client::registry::Registry;
 
 #[derive(Clone)]
 pub struct DispatcherMetrics {
-    pub expired_particles: Counter,
+    pub expired_particles: Family<ParticleLabel, Counter>,
 }
 
 impl DispatcherMetrics {
@@ -23,7 +25,7 @@ impl DispatcherMetrics {
         //     Box::new(parallelism),
         // );
 
-        let expired_particles = Counter::default();
+        let expired_particles = Family::default();
         sub_registry.register(
             "particles_expired",
             "Number of particles expired by TTL",
@@ -31,5 +33,13 @@ impl DispatcherMetrics {
         );
 
         DispatcherMetrics { expired_particles }
+    }
+
+    pub fn particle_expired(&self, particle_id: &str) {
+        self.expired_particles
+            .get_or_create(&ParticleLabel {
+                particle_type: ParticleType::from_particle(particle_id),
+            })
+            .inc();
     }
 }

--- a/crates/peer-metrics/src/lib.rs
+++ b/crates/peer-metrics/src/lib.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use prometheus_client::encoding::EncodeMetric;
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, EncodeMetric};
 use prometheus_client::registry::Registry;
 
 pub use connection_pool::ConnectionPoolMetrics;
@@ -28,6 +28,27 @@ mod vm_pool;
 // - individual actor mailbox size: max and histogram
 // - count 'Error processing inbound ProtocolMessage: unexpected end of file'
 // - number of scheduled script executions
+
+#[derive(EncodeLabelValue, Hash, Clone, Eq, PartialEq, Debug)]
+pub enum ParticleType {
+    Spell,
+    Common,
+}
+
+impl ParticleType {
+    fn from_particle(particle_id: &str) -> Self {
+        if particle_id.starts_with("spell_") {
+            ParticleType::Spell
+        } else {
+            ParticleType::Common
+        }
+    }
+}
+
+#[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+pub struct ParticleLabel {
+    particle_type: ParticleType,
+}
 
 /// from 100 microseconds to 120 seconds
 pub(self) fn execution_time_buckets() -> std::vec::IntoIter<f64> {

--- a/particle-node/src/connectivity.rs
+++ b/particle-node/src/connectivity.rs
@@ -129,11 +129,15 @@ impl Connectivity {
         let sent = self.connection_pool.send(contact.clone(), particle).await;
         match &sent {
             SendStatus::Ok => {
-                metrics.map(|m| m.send_particle_ok(&id));
+                if let Some(m) = metrics {
+                    m.send_particle_ok(&id)
+                }
                 log::info!("Sent particle {} to {}", id, contact);
             }
             err => {
-                metrics.map(|m| m.send_particle_failed(&id));
+                if let Some(m) = metrics {
+                    m.send_particle_failed(&id);
+                }
                 log::warn!(
                     "Failed to send particle {} to {}, reason: {:?}",
                     id,

--- a/particle-node/src/connectivity.rs
+++ b/particle-node/src/connectivity.rs
@@ -129,11 +129,11 @@ impl Connectivity {
         let sent = self.connection_pool.send(contact.clone(), particle).await;
         match &sent {
             SendStatus::Ok => {
-                metrics.map(|m| m.particle_send_success.inc());
+                metrics.map(|m| m.send_particle_ok(&id));
                 log::info!("Sent particle {} to {}", id, contact);
             }
             err => {
-                metrics.map(|m| m.particle_send_failure.inc());
+                metrics.map(|m| m.send_particle_failed(&id));
                 log::warn!(
                     "Failed to send particle {} to {}, reason: {:?}",
                     id,

--- a/particle-node/src/dispatcher.rs
+++ b/particle-node/src/dispatcher.rs
@@ -94,7 +94,7 @@ impl Dispatcher {
                 let metrics = metrics.clone();
 
                 if particle.is_expired() {
-                    metrics.map(|m| m.expired_particles.inc());
+                    metrics.map(|m| m.particle_expired(&particle.id));
                     log::info!("Particle {} expired", particle.id);
                     return async {}.boxed();
                 }

--- a/particle-node/src/dispatcher.rs
+++ b/particle-node/src/dispatcher.rs
@@ -94,7 +94,9 @@ impl Dispatcher {
                 let metrics = metrics.clone();
 
                 if particle.is_expired() {
-                    metrics.map(|m| m.particle_expired(&particle.id));
+                    if let Some(m) = metrics {
+                        m.particle_expired(&particle.id);
+                    }
                     log::info!("Particle {} expired", particle.id);
                     return async {}.boxed();
                 }


### PR DESCRIPTION
Added a separate metrics collection for a number of partcile metrics:
 * received_particles
 * particle_sizes
 * particle_send_success
 * particle_send_failure
 * expired_particles
 
Each of the metrics above now has a label with "Common" for every common particle and "Spell" for `spell_` prefixed particles.

I chose this metrics because it made sense to me, but I'm open to discussion. 