### PR TITLE
feat(metrics): add rust-peer version info in prometheus metrics [fixes NET-422]

### DIFF
--- a/crates/peer-metrics/src/info.rs
+++ b/crates/peer-metrics/src/info.rs
@@ -13,5 +13,5 @@ pub fn add_info_metrics(
         ("air-version", air_version),
         ("spell-version", spell_version),
     ]);
-    sub_registry.register("version", "Rust Peer versions", info);
+    sub_registry.register("build", "Rust Peer Info", info);
 }

--- a/crates/peer-metrics/src/info.rs
+++ b/crates/peer-metrics/src/info.rs
@@ -3,13 +3,15 @@ use prometheus_client::registry::Registry;
 
 pub fn add_info_metrics(
     registry: &mut Registry,
-    node_version: &'static str,
-    air_version: &'static str,
+    node_version: String,
+    air_version: String,
+    spell_version: String,
 ) {
     let sub_registry = registry.sub_registry_with_prefix("rust_peer_info");
     let info = Info::new(vec![
         ("peer-version", node_version),
         ("air-version", air_version),
+        ("spell-version", spell_version),
     ]);
     sub_registry.register("version", "Rust Peer versions", info);
 }

--- a/crates/peer-metrics/src/info.rs
+++ b/crates/peer-metrics/src/info.rs
@@ -1,0 +1,15 @@
+use prometheus_client::metrics::info::Info;
+use prometheus_client::registry::Registry;
+
+pub fn add_info_metrics(
+    registry: &mut Registry,
+    node_version: &'static str,
+    air_version: &'static str,
+) {
+    let sub_registry = registry.sub_registry_with_prefix("rust_peer_info");
+    let info = Info::new(vec![
+        ("peer-version", node_version),
+        ("air-version", air_version),
+    ]);
+    sub_registry.register("version", "Rust Peer versions", info);
+}

--- a/crates/peer-metrics/src/info.rs
+++ b/crates/peer-metrics/src/info.rs
@@ -7,7 +7,7 @@ pub fn add_info_metrics(
     air_version: String,
     spell_version: String,
 ) {
-    let sub_registry = registry.sub_registry_with_prefix("rust_peer_info");
+    let sub_registry = registry.sub_registry_with_prefix("rust_peer");
     let info = Info::new(vec![
         ("peer-version", node_version),
         ("air-version", air_version),

--- a/crates/peer-metrics/src/lib.rs
+++ b/crates/peer-metrics/src/lib.rs
@@ -7,6 +7,7 @@ pub use connection_pool::ConnectionPoolMetrics;
 pub use connectivity::ConnectivityMetrics;
 pub use connectivity::Resolution;
 pub use dispatcher::DispatcherMetrics;
+pub use info::add_info_metrics;
 pub use particle_executor::{FunctionKind, ParticleExecutorMetrics};
 pub use services_metrics::{
     ServiceCallStats, ServiceMemoryStat, ServiceType, ServicesMetrics, ServicesMetricsBackend,
@@ -17,6 +18,7 @@ pub use vm_pool::VmPoolMetrics;
 mod connection_pool;
 mod connectivity;
 mod dispatcher;
+mod info;
 mod network_protocol;
 mod particle_executor;
 mod services_metrics;

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -266,6 +266,9 @@ impl<RT: AquaRuntime> Node<RT> {
             spell_version,
             allowed_binaries,
         };
+        metrics_registry.as_mut().map(|r| {
+            peer_metrics::add_info_metrics(r, node_info.node_version, node_info.air_version);
+        });
         custom_service_functions.extend_one(make_peer_builtin(node_info));
 
         custom_service_functions.into_iter().for_each(

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -271,7 +271,7 @@ impl<RT: AquaRuntime> Node<RT> {
                 m,
                 node_info.node_version.to_string(),
                 node_info.air_version.to_string(),
-                node_info.spell_version,
+                node_info.spell_version.clone(),
             );
         }
         custom_service_functions.extend_one(make_peer_builtin(node_info));

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -266,9 +266,14 @@ impl<RT: AquaRuntime> Node<RT> {
             spell_version,
             allowed_binaries,
         };
-        metrics_registry.as_mut().map(|r| {
-            peer_metrics::add_info_metrics(r, node_info.node_version, node_info.air_version);
-        });
+        if let Some(m) = metrics_registry.as_mut() {
+            peer_metrics::add_info_metrics(
+                m,
+                node_info.node_version.to_string(),
+                node_info.air_version.to_string(),
+                node_info.spell_version,
+            );
+        }
         custom_service_functions.extend_one(make_peer_builtin(node_info));
 
         custom_service_functions.into_iter().for_each(


### PR DESCRIPTION
Add new `rust_peer_build_info` metric.
```
# HELP rust_peer_info_version Rust Peer version.
# TYPE rust_peer_info_version info
rust_peer_version_info{peer-version="0.9.1",air-version="0.38.0",spell-version="0.5.6"} 1
```
These versions are the same as in `Peer.identify`: `peer-version` is from `CARGO_PKG_VERSION`, `air-version` is `air_interpreter_wasm::VERSION`.

~~I think, atm it's enough to add only basic versions. Suggest to extend it when we feel that we need it.~~
UPD: ~~I'll add spell version and builtins versions.~~
UPD: added spell_version