### PR TITLE
feat!(vault): do not create vault on every particle

### DIFF
--- a/aquamarine/src/particle_data_store.rs
+++ b/aquamarine/src/particle_data_store.rs
@@ -83,7 +83,7 @@ impl DataStore for ParticleDataStore {
     fn initialize(&mut self) -> Result<()> {
         create_dir(&self.particle_data_store).map_err(CreateDataStore)?;
 
-        self.vault.initialize()?;
+        // self.vault.initialize()?;
 
         Ok(())
     }


### PR DESCRIPTION
Particle File Vault should be created only on service calls