### PR TITLE
feat(builtins)!: start spells only after builtins are deployed

### DIFF
--- a/crates/builtins-deployer/src/builtins_deployer.rs
+++ b/crates/builtins-deployer/src/builtins_deployer.rs
@@ -385,6 +385,8 @@ impl BuiltinsDeployer {
             log::info!("Builtin service {} successfully started", builtin.name);
         }
 
+        log::info!("Finished. Exiting.");
+
         Ok(())
     }
 

--- a/crates/log-utils/src/lib.rs
+++ b/crates/log-utils/src/lib.rs
@@ -61,8 +61,10 @@ pub fn enable_logs() {
         .filter(Some("async_std"), Info)
         .filter(Some("async_io"), Info)
         .filter(Some("polling"), Info)
-        .filter(Some("cranelift_codegen"), Info)
-        .filter(Some("walrus"), Info)
+        .filter(Some("cranelift_codegen"), Warn)
+        .filter(Some("walrus"), Off)
+        .filter(Some("tracing"), Off)
+        .filter(Some("avm_server"), Off)
         .try_init()
         .ok();
 }

--- a/crates/particle-node-tests/tests/builtin.rs
+++ b/crates/particle-node-tests/tests/builtin.rs
@@ -32,6 +32,7 @@ use key_manager::INSECURE_KEYPAIR_SEED;
 use libp2p::core::Multiaddr;
 use libp2p::kad::kbucket::Key;
 use libp2p::PeerId;
+use log_utils::enable_logs;
 use maplit::hashmap;
 use now_millis::now_ms;
 use particle_protocol::Particle;

--- a/crates/particle-node-tests/tests/spells.rs
+++ b/crates/particle-node-tests/tests/spells.rs
@@ -26,6 +26,7 @@ use serde_json::{json, Value as JValue};
 use connected_client::ConnectedClient;
 use created_swarm::{make_swarms, make_swarms_with_builtins};
 use fluence_spell_dtos::trigger_config::{ClockConfig, TriggerConfig};
+use log_utils::enable_logs;
 use service_modules::load_module;
 use spell_event_bus::api::{TriggerInfo, TriggerInfoAqua, MAX_PERIOD_SEC};
 use test_utils::{create_service, create_service_worker};
@@ -111,6 +112,8 @@ fn make_clock_config(period_sec: u32, start_sec: u32, end_sec: u32) -> TriggerCo
 
 #[tokio::test]
 async fn spell_simple_test() {
+    enable_logs();
+
     let swarms = make_swarms(1).await;
 
     let mut client = ConnectedClient::connect_to(swarms[0].multiaddr.clone())

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -442,7 +442,6 @@ impl<RT: AquaRuntime> Node<RT> {
 
             let services_metrics_backend = services_metrics_backend.start();
             let script_storage = script_storage.start();
-            let spell_event_bus = spell_event_bus.start();
             let sorcerer = sorcerer.start(spell_events_receiver);
             let pool = aquavm_pool.start();
             let mut connectivity = connectivity.start();
@@ -471,7 +470,7 @@ impl<RT: AquaRuntime> Node<RT> {
             log::info!("Stopping node");
             services_metrics_backend.abort();
             script_storage.abort();
-            spell_event_bus.abort();
+            // spell_event_bus.abort();
             sorcerer.abort();
             dispatcher.cancel().await;
             connectivity.cancel().await;
@@ -483,6 +482,8 @@ impl<RT: AquaRuntime> Node<RT> {
             .deploy_builtin_services()
             .await
             .wrap_err("builtins deploy failed")?;
+
+        spell_event_bus.start();
 
         Ok(exit_outlet)
     }

--- a/particle-node/src/node.rs
+++ b/particle-node/src/node.rs
@@ -23,7 +23,6 @@ use aquamarine::{
 use builtins_deployer::BuiltinsDeployer;
 use config_utils::to_peer_id;
 use connection_pool::{ConnectionPoolApi, ConnectionPoolT};
-use eyre::WrapErr;
 use fluence_libp2p::build_transport;
 use futures::{stream::StreamExt, FutureExt};
 use key_manager::KeyManager;
@@ -421,7 +420,7 @@ impl<RT: AquaRuntime> Node<RT> {
         let dispatcher = self.dispatcher;
         let aquavm_pool = self.aquavm_pool;
         let script_storage = self.script_storage;
-        let spell_event_bus = self.spell_event_bus;
+        let mut spell_event_bus = Some(self.spell_event_bus);
         let spell_events_receiver = self.spell_events_receiver;
         let sorcerer = self.sorcerer;
         let registry = self.registry;
@@ -431,6 +430,7 @@ impl<RT: AquaRuntime> Node<RT> {
             .map(|x| format!("node-{x}"))
             .unwrap_or("node".to_owned());
         let libp2p_metrics = self.libp2p_metrics;
+        let mut builtins_deployer = self.builtins_deployer;
 
         task::Builder::new().name(&task_name.clone()).spawn(async move {
             let mut metrics_fut= if let Some(registry) = registry {
@@ -448,6 +448,8 @@ impl<RT: AquaRuntime> Node<RT> {
             let mut dispatcher = dispatcher.start(particle_stream, effects_stream);
             let mut exit_inlet = Some(exit_inlet);
 
+            let mut builtins_f = builtins_deployer.deploy_builtin_services().boxed().fuse();
+
             loop {
                 let exit_inlet = exit_inlet.as_mut().expect("Could not get exit inlet");
                 tokio::select! {
@@ -460,6 +462,10 @@ impl<RT: AquaRuntime> Node<RT> {
                     _ = &mut metrics_fut => {},
                     _ = &mut connectivity => {},
                     _ = &mut dispatcher => {},
+                    _ = &mut builtins_f => {
+                        log::info!("builtins_f finished! Starting spell bus");
+                        spell_event_bus.take().map(|bus| bus.start());
+                    },
                     _ = exit_inlet => {
                         log::info!("Exit inlet");
                         break;
@@ -477,13 +483,11 @@ impl<RT: AquaRuntime> Node<RT> {
             pool.abort();
         }).expect("Could not spawn task");
 
-        let mut builtins_deployer = self.builtins_deployer;
-        builtins_deployer
-            .deploy_builtin_services()
-            .await
-            .wrap_err("builtins deploy failed")?;
-
-        spell_event_bus.start();
+        // let mut builtins_deployer = self.builtins_deployer;
+        // builtins_deployer
+        //     .deploy_builtin_services()
+        //     .await
+        //     .wrap_err("builtins deploy failed")?;
 
         Ok(exit_outlet)
     }


### PR DESCRIPTION
It doesn't work :(

Goal is to wait for builtins to deploy before unleashing full load. But it seems that without SpellEventBus it is impossible to deploy Decider.