### PR TITLE
fix(metrics): restrict metrics collection of aliased service on creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,7 +4501,6 @@ dependencies = [
  "fluence-libp2p",
  "futures",
  "humantime-serde",
- "itertools",
  "json-utils",
  "libp2p",
  "log",

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -841,7 +841,12 @@ impl ParticleAppServices {
         })?;
         let stats = service.module_memory_stats();
         let stats = ServiceMemoryStat::new(&stats);
-        let service_type = ServiceType::Service(aliases.first().cloned());
+        let allowed_alias = if worker_id == self.config.local_peer_id {
+            aliases.first().cloned()
+        } else {
+            None
+        };
+        let service_type = ServiceType::Service(allowed_alias);
         let service = Service::new(
             Mutex::new(service),
             service_id.clone(),


### PR DESCRIPTION
Forgot to fix collection of mem metrics on service creation.