### PR TITLE
feat: add service metrics for spells [fixes NET-441]

### DIFF
--- a/crates/peer-metrics/src/services_metrics/external.rs
+++ b/crates/peer-metrics/src/services_metrics/external.rs
@@ -100,7 +100,7 @@ impl ServicesMetricsExternal {
 
         let services_count: Family<_, _> = register(
             sub_registry,
-            Family::new_with_constructor(|| Gauge::default()),
+            Family::new_with_constructor(Gauge::default),
             "services_count",
             "number of currently running services",
         );
@@ -121,14 +121,14 @@ impl ServicesMetricsExternal {
 
         let creation_count: Family<_, _> = register(
             sub_registry,
-            Family::new_with_constructor(|| Counter::default()),
+            Family::new_with_constructor(Counter::default),
             "creation_count",
             "number of srv create calls",
         );
 
         let removal_count: Family<_, _> = register(
             sub_registry,
-            Family::new_with_constructor(|| Counter::default()),
+            Family::new_with_constructor(Counter::default),
             "removal_count",
             "number of srv remove calls",
         );

--- a/crates/peer-metrics/src/services_metrics/mod.rs
+++ b/crates/peer-metrics/src/services_metrics/mod.rs
@@ -150,7 +150,11 @@ impl ServicesMetrics {
         creation_time: f64,
     ) {
         self.observe_external(|external| {
-            external.observe_created(stats.modules_stats.len() as f64, creation_time);
+            external.observe_created(
+                service_type.clone(),
+                stats.modules_stats.len() as f64,
+                creation_time,
+            );
             self.observe_service_mem(service_id, service_type, stats);
         });
     }
@@ -161,9 +165,9 @@ impl ServicesMetrics {
         });
     }
 
-    pub fn observe_removed(&self, removal_time: f64) {
+    pub fn observe_removed(&self, service_type: ServiceType, removal_time: f64) {
         self.observe_external(|external| {
-            external.observe_removed(removal_time);
+            external.observe_removed(service_type, removal_time);
         });
     }
 

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -872,12 +872,7 @@ impl ParticleAppServices {
         } else {
             None
         };
-        // How to detect that the service is a spell?
-        // Afaik there's no way to detect that the service is a spell FAST
-        // We can check blueprint name, but it's not reliable
-        // Need to rework that
 
-        // This approach doesn't work since not only spells calls spell functions
         if service.is_spell {
             ServiceType::Spell(allowed_alias)
         } else {

--- a/particle-services/src/app_services.rs
+++ b/particle-services/src/app_services.rs
@@ -60,10 +60,7 @@ pub enum ServiceType {
 
 impl ServiceType {
     fn is_spell(&self) -> bool {
-        match self {
-            ServiceType::Spell => true,
-            _ => false,
-        }
+        matches!(self, ServiceType::Spell)
     }
 }
 
@@ -442,7 +439,7 @@ impl ParticleAppServices {
         //     ));
         // }
         // Metrics collection are enables for services with aliases which are installed on root worker or worker spells.
-        let service_type = self.get_service_type(&service, &worker_id);
+        let service_type = self.get_service_type(service, &worker_id);
 
         // TODO: move particle vault creation to aquamarine::particle_functions
         self.create_vault(&particle.id)?;


### PR DESCRIPTION
Add a new service type for spells and spells with aliases.

Extend some new metrics with labels:
* services_count
* creation_time_msec
* removal_time_msec
* creation_count
* removal_count

And add a __hack__ to detect that a service is a spell _fast_, without rechecking the blueprint cache on every call.

Need to design a non-hacky way to distinguish a service and a spell, I think. It will be needed not only for this metrics collection thing but also for rewriting the registry and other built-in services as spells.  